### PR TITLE
Add touchpoints and runtime property constraints

### DIFF
--- a/src/data_types.rs
+++ b/src/data_types.rs
@@ -352,6 +352,82 @@ impl PropertyChangedEvent {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NcTouchpointResourceNmos {
+    #[serde(rename = "resourceType")]
+    pub resource_type: String,
+    pub id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NcTouchpointResourceNmosChannelMapping {
+    #[serde(rename = "resourceType")]
+    pub resource_type: String,
+    pub id: String,
+    #[serde(rename = "ioId")]
+    pub io_id: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NcTouchpointBase {
+    #[serde(rename = "contextNamespace")]
+    pub context_namespace: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NcTouchpointNmos {
+    #[serde(flatten)]
+    pub base: NcTouchpointBase,
+    pub resource: NcTouchpointResourceNmos,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NcTouchpointNmosChannelMapping {
+    #[serde(flatten)]
+    pub base: NcTouchpointBase,
+    pub resource: NcTouchpointResourceNmosChannelMapping,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum NcTouchpoint {
+    Nmos(NcTouchpointNmos),
+    NmosChannelMapping(NcTouchpointNmosChannelMapping),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NcPropertyConstraintsBase {
+    #[serde(rename = "propertyId")]
+    pub property_id: ElementId,
+    #[serde(rename = "defaultValue")]
+    pub default_value: Option<Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NcPropertyConstraintsNumber {
+    #[serde(flatten)]
+    pub base: NcPropertyConstraintsBase,
+    pub maximum: Option<f64>,
+    pub minimum: Option<f64>,
+    pub step: Option<f64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NcPropertyConstraintsString {
+    #[serde(flatten)]
+    pub base: NcPropertyConstraintsBase,
+    #[serde(rename = "maxCharacters")]
+    pub max_characters: Option<u32>,
+    pub pattern: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum NcPropertyConstraints {
+    Number(NcPropertyConstraintsNumber),
+    String(NcPropertyConstraintsString),
+}
+
 #[derive(Serialize, Debug)]
 pub struct WsNotificationMessage {
     pub notifications: Vec<PropertyChangedEvent>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -157,6 +157,8 @@ async fn main() -> anyhow::Result<()> {
         "root",
         None,
         true,
+        None,
+        None,
         tx.clone(),
     );
 
@@ -166,6 +168,18 @@ async fn main() -> anyhow::Result<()> {
         Some(1),
         "DeviceManager",
         Some("Device Manager"),
+        Some(vec![crate::data_types::NcTouchpoint::Nmos(
+            crate::data_types::NcTouchpointNmos {
+                base: crate::data_types::NcTouchpointBase {
+                    context_namespace: "x-nmos".into(),
+                },
+                resource: crate::data_types::NcTouchpointResourceNmos {
+                    resource_type: "device".into(),
+                    id: device.base.id.clone(),
+                },
+            },
+        )]),
+        None,
         "v1.0.0".to_string(),
         NcManufacturer {
             name: "Your Company".to_string(),
@@ -193,6 +207,8 @@ async fn main() -> anyhow::Result<()> {
         Some(1),
         "my-obj-01",
         Some("My object 01"),
+        None,
+        None,
         tx.clone(),
     );
     root.add_member(Box::new(obj_1));
@@ -207,6 +223,8 @@ async fn main() -> anyhow::Result<()> {
         "my-block-01",
         None,
         true,
+        None,
+        None,
         tx.clone(),
     );
     let obj_2 = NcObject::new(
@@ -215,6 +233,8 @@ async fn main() -> anyhow::Result<()> {
         true,
         Some(1),
         "my-nested-block-obj",
+        None,
+        None,
         None,
         tx.clone(),
     );

--- a/src/nc_block.rs
+++ b/src/nc_block.rs
@@ -143,6 +143,8 @@ impl NcBlock {
         role: &str,
         user_label: Option<&str>,
         enabled: bool,
+        touchpoints: Option<Vec<crate::data_types::NcTouchpoint>>,
+        runtime_property_constraints: Option<Vec<crate::data_types::NcPropertyConstraints>>,
         notifier: mpsc::UnboundedSender<PropertyChangedEvent>,
     ) -> Self {
         NcBlock {
@@ -153,6 +155,8 @@ impl NcBlock {
                 owner,
                 role,
                 user_label,
+                touchpoints,
+                runtime_property_constraints,
                 notifier,
             ),
             is_root,

--- a/src/nc_device_manager.rs
+++ b/src/nc_device_manager.rs
@@ -1,7 +1,7 @@
 use crate::data_types::{
     ElementId, IdArgs, IdArgsValue, NcDeviceGenericState, NcDeviceOperationalState, NcManufacturer,
-    NcMethodStatus, NcProduct, NcPropertyChangeType, NcResetCause, PropertyChangedEvent,
-    PropertyChangedEventData,
+    NcMethodStatus, NcProduct, NcPropertyChangeType, NcPropertyConstraints, NcResetCause,
+    NcTouchpoint, PropertyChangedEvent, PropertyChangedEventData,
 };
 use crate::nc_object::{NcMember, NcObject};
 use serde_json::{Value, json};
@@ -179,6 +179,8 @@ impl NcDeviceManager {
         owner: Option<u64>,
         role: &str,
         user_label: Option<&str>,
+        touchpoints: Option<Vec<NcTouchpoint>>,
+        runtime_property_constraints: Option<Vec<NcPropertyConstraints>>,
         nc_version: String,
         manufacturer: NcManufacturer,
         product: NcProduct,
@@ -193,6 +195,8 @@ impl NcDeviceManager {
                 owner,
                 role,
                 user_label,
+                touchpoints,
+                runtime_property_constraints,
                 notifier,
             ),
             nc_version,


### PR DESCRIPTION
- add datatypes for touchpoints
- add datatypes for runtime property constraints
- add touchpoints (level 1 index 7) to NcObject and any derived entity
- add runtime property constraints (level 1 index 8) to NcObject and any derived entity
- update constructors in main for all entities