### PR TITLE
Implementing Class and Datatype discovery

### DIFF
--- a/src/data_types.rs
+++ b/src/data_types.rs
@@ -10,62 +10,6 @@ pub const MESSAGE_TYPE_SUBSCRIPTION: u16 = 3;
 pub const MESSAGE_TYPE_SUBSCRIPTION_RESPONSE: u16 = 4;
 pub const MESSAGE_TYPE_ERROR: u16 = 5;
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
-#[serde(into = "u16", try_from = "u16")]
-#[repr(u16)]
-pub enum NcMethodStatus {
-    Ok = 200,
-    PropertyDeprecated = 298,
-    MethodDeprecated = 299,
-    BadCommandFormat = 400,
-    Unauthorized = 401,
-    BadOid = 404,
-    Readonly = 405,
-    InvalidRequest = 406,
-    Conflict = 409,
-    BufferOverflow = 413,
-    IndexOutOfBounds = 414,
-    ParameterError = 417,
-    Locked = 423,
-    DeviceError = 500,
-    MethodNotImplemented = 501,
-    PropertyNotImplemented = 502,
-    NotReady = 503,
-    Timeout = 504,
-}
-
-impl From<NcMethodStatus> for u16 {
-    fn from(status: NcMethodStatus) -> Self {
-        status as u16
-    }
-}
-
-impl From<u16> for NcMethodStatus {
-    fn from(value: u16) -> Self {
-        match value {
-            200 => NcMethodStatus::Ok,
-            298 => NcMethodStatus::PropertyDeprecated,
-            299 => NcMethodStatus::MethodDeprecated,
-            400 => NcMethodStatus::BadCommandFormat,
-            401 => NcMethodStatus::Unauthorized,
-            404 => NcMethodStatus::BadOid,
-            405 => NcMethodStatus::Readonly,
-            406 => NcMethodStatus::InvalidRequest,
-            409 => NcMethodStatus::Conflict,
-            413 => NcMethodStatus::BufferOverflow,
-            414 => NcMethodStatus::IndexOutOfBounds,
-            417 => NcMethodStatus::ParameterError,
-            423 => NcMethodStatus::Locked,
-            500 => NcMethodStatus::DeviceError,
-            501 => NcMethodStatus::MethodNotImplemented,
-            502 => NcMethodStatus::PropertyNotImplemented,
-            503 => NcMethodStatus::NotReady,
-            504 => NcMethodStatus::Timeout,
-            _ => NcMethodStatus::DeviceError,
-        }
-    }
-}
-
 #[derive(Serialize, Clone)]
 pub struct NmosResource {
     pub id: String,
@@ -198,10 +142,1724 @@ impl NmosNode {
     }
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(into = "u16", try_from = "u16")]
+#[repr(u16)]
+pub enum NcMethodStatus {
+    Ok = 200,
+    PropertyDeprecated = 298,
+    MethodDeprecated = 299,
+    BadCommandFormat = 400,
+    Unauthorized = 401,
+    BadOid = 404,
+    Readonly = 405,
+    InvalidRequest = 406,
+    Conflict = 409,
+    BufferOverflow = 413,
+    IndexOutOfBounds = 414,
+    ParameterError = 417,
+    Locked = 423,
+    DeviceError = 500,
+    MethodNotImplemented = 501,
+    PropertyNotImplemented = 502,
+    NotReady = 503,
+    Timeout = 504,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NcTouchpointResourceBase {
+    #[serde(rename = "resourceType")]
+    pub resource_type: String,
+}
+
+impl NcTouchpointResourceBase {
+    pub fn get_type_descriptor(_include_inherited: bool) -> NcDatatypeDescriptorStruct {
+        NcDatatypeDescriptorStruct {
+            base: NcDatatypeDescriptor {
+                base: NcDescriptor {
+                    description: Some("Touchpoint resource".to_string()),
+                },
+                name: "NcTouchpointResource".to_string(),
+                type_: NcDatatypeType::Struct,
+                constraints: None,
+            },
+            fields: vec![NcFieldDescriptor {
+                base: NcDescriptor { description: None },
+                name: "resourceType".to_string(),
+                type_name: Some("NcString".to_string()),
+                is_nullable: false,
+                is_sequence: false,
+                constraints: None,
+            }],
+            parent_type: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NcTouchpointResourceNmos {
+    #[serde(flatten)]
+    pub base: NcTouchpointResourceBase,
+    pub id: String,
+}
+
+impl NcTouchpointResourceNmos {
+    pub fn get_type_descriptor(include_inherited: bool) -> NcDatatypeDescriptorStruct {
+        let mut current = NcDatatypeDescriptorStruct {
+            base: NcDatatypeDescriptor {
+                base: NcDescriptor {
+                    description: Some("Touchpoint NMOS resource".to_string()),
+                },
+                name: "NcTouchpointResourceNmos".to_string(),
+                type_: NcDatatypeType::Struct,
+                constraints: None,
+            },
+            fields: vec![NcFieldDescriptor {
+                base: NcDescriptor { description: None },
+                name: "id".to_string(),
+                type_name: Some("NcUuid".to_string()),
+                is_nullable: false,
+                is_sequence: false,
+                constraints: None,
+            }],
+            parent_type: Some("NcTouchpointResource".to_string()),
+        };
+        if include_inherited {
+            let base = NcTouchpointResourceBase::get_type_descriptor(true);
+            current.fields.extend(base.fields);
+        }
+        current
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NcTouchpointResourceNmosChannelMapping {
+    #[serde(flatten)]
+    pub base: NcTouchpointResourceNmos,
+    #[serde(rename = "ioId")]
+    pub io_id: String,
+}
+
+impl NcTouchpointResourceNmosChannelMapping {
+    pub fn get_type_descriptor(include_inherited: bool) -> NcDatatypeDescriptorStruct {
+        let mut current = NcDatatypeDescriptorStruct {
+            base: NcDatatypeDescriptor {
+                base: NcDescriptor {
+                    description: Some("Touchpoint NMOS channel mapping resource".to_string()),
+                },
+                name: "NcTouchpointResourceNmosChannelMapping".to_string(),
+                type_: NcDatatypeType::Struct,
+                constraints: None,
+            },
+            fields: vec![NcFieldDescriptor {
+                base: NcDescriptor { description: None },
+                name: "ioId".to_string(),
+                type_name: Some("NcString".to_string()),
+                is_nullable: false,
+                is_sequence: false,
+                constraints: None,
+            }],
+            parent_type: Some("NcTouchpointResourceNmos".to_string()),
+        };
+        if include_inherited {
+            let base = NcTouchpointResourceNmos::get_type_descriptor(true);
+            current.fields.extend(base.fields);
+        }
+        current
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum NcTouchpoint {
+    Nmos(NcTouchpointNmos),
+    NmosChannelMapping(NcTouchpointNmosChannelMapping),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NcTouchpointBase {
+    #[serde(rename = "contextNamespace")]
+    pub context_namespace: String,
+}
+
+impl NcTouchpointBase {
+    pub fn get_type_descriptor(_include_inherited: bool) -> NcDatatypeDescriptorStruct {
+        NcDatatypeDescriptorStruct {
+            base: NcDatatypeDescriptor {
+                base: NcDescriptor {
+                    description: Some("Touchpoint".to_string()),
+                },
+                name: "NcTouchpoint".to_string(),
+                type_: NcDatatypeType::Struct,
+                constraints: None,
+            },
+            fields: vec![NcFieldDescriptor {
+                base: NcDescriptor { description: None },
+                name: "contextNamespace".to_string(),
+                type_name: Some("NcString".to_string()),
+                is_nullable: false,
+                is_sequence: false,
+                constraints: None,
+            }],
+            parent_type: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NcTouchpointNmos {
+    #[serde(flatten)]
+    pub base: NcTouchpointBase,
+    pub resource: NcTouchpointResourceNmos,
+}
+
+impl NcTouchpointNmos {
+    pub fn get_type_descriptor(include_inherited: bool) -> NcDatatypeDescriptorStruct {
+        let mut current = NcDatatypeDescriptorStruct {
+            base: NcDatatypeDescriptor {
+                base: NcDescriptor {
+                    description: Some("Touchpoint NMOS".to_string()),
+                },
+                name: "NcTouchpointNmos".to_string(),
+                type_: NcDatatypeType::Struct,
+                constraints: None,
+            },
+            fields: vec![NcFieldDescriptor {
+                base: NcDescriptor { description: None },
+                name: "resource".to_string(),
+                type_name: Some("NcTouchpointResourceNmos".to_string()),
+                is_nullable: false,
+                is_sequence: false,
+                constraints: None,
+            }],
+            parent_type: Some("NcTouchpoint".to_string()),
+        };
+        if include_inherited {
+            let base = NcTouchpointBase::get_type_descriptor(true);
+            current.fields.extend(base.fields);
+        }
+        current
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NcTouchpointNmosChannelMapping {
+    #[serde(flatten)]
+    pub base: NcTouchpointBase,
+    pub resource: NcTouchpointResourceNmosChannelMapping,
+}
+
+impl NcTouchpointNmosChannelMapping {
+    pub fn get_type_descriptor(include_inherited: bool) -> NcDatatypeDescriptorStruct {
+        let mut current = NcDatatypeDescriptorStruct {
+            base: NcDatatypeDescriptor {
+                base: NcDescriptor {
+                    description: Some("Touchpoint NMOS channel mapping".to_string()),
+                },
+                name: "NcTouchpointNmosChannelMapping".to_string(),
+                type_: NcDatatypeType::Struct,
+                constraints: None,
+            },
+            fields: vec![NcFieldDescriptor {
+                base: NcDescriptor { description: None },
+                name: "resource".to_string(),
+                type_name: Some("NcTouchpointResourceNmosChannelMapping".to_string()),
+                is_nullable: false,
+                is_sequence: false,
+                constraints: None,
+            }],
+            parent_type: Some("NcTouchpoint".to_string()),
+        };
+        if include_inherited {
+            let base = NcTouchpointBase::get_type_descriptor(true);
+            current.fields.extend(base.fields);
+        }
+        current
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NcDescriptor {
+    pub description: Option<String>,
+}
+
+impl NcDescriptor {
+    pub fn get_type_descriptor(_include_inherited: bool) -> NcDatatypeDescriptorStruct {
+        NcDatatypeDescriptorStruct {
+            base: NcDatatypeDescriptor {
+                name: "NcDescriptor".to_string(),
+                type_: NcDatatypeType::Struct,
+                constraints: None,
+                base: NcDescriptor {
+                    description: Some("Base descriptor".to_string()),
+                },
+            },
+            fields: vec![NcFieldDescriptor {
+                base: NcDescriptor {
+                    description: Some("Optional user facing description".to_string()),
+                },
+                name: "description".to_string(),
+                type_name: Some("NcString".to_string()),
+                is_nullable: true,
+                is_sequence: false,
+                constraints: None,
+            }],
+            parent_type: None,
+        }
+    }
+}
+
+#[derive(Serialize, Debug)]
+pub struct NcBlockMemberDescriptor {
+    #[serde(flatten)]
+    pub base: NcDescriptor,
+    pub role: String,
+    pub oid: u64,
+    #[serde(rename = "constantOid")]
+    pub constant_oid: bool,
+    #[serde(rename = "classId")]
+    pub class_id: Vec<u32>,
+    #[serde(rename = "userLabel")]
+    pub user_label: String,
+    pub owner: u64,
+}
+
+impl NcBlockMemberDescriptor {
+    pub fn get_type_descriptor(include_inherited: bool) -> NcDatatypeDescriptorStruct {
+        let mut current = NcDatatypeDescriptorStruct {
+            base: NcDatatypeDescriptor {
+                base: NcDescriptor {
+                    description: Some("Block member descriptor".to_string()),
+                },
+                name: "NcBlockMemberDescriptor".to_string(),
+                type_: NcDatatypeType::Struct,
+                constraints: None,
+            },
+            fields: vec![
+                NcFieldDescriptor {
+                    base: NcDescriptor { description: None },
+                    name: "role".to_string(),
+                    type_name: Some("NcString".to_string()),
+                    is_nullable: false,
+                    is_sequence: false,
+                    constraints: None,
+                },
+                NcFieldDescriptor {
+                    base: NcDescriptor { description: None },
+                    name: "oid".to_string(),
+                    type_name: Some("NcOid".to_string()),
+                    is_nullable: false,
+                    is_sequence: false,
+                    constraints: None,
+                },
+                NcFieldDescriptor {
+                    base: NcDescriptor { description: None },
+                    name: "constantOid".to_string(),
+                    type_name: Some("NcBoolean".to_string()),
+                    is_nullable: false,
+                    is_sequence: false,
+                    constraints: None,
+                },
+                NcFieldDescriptor {
+                    base: NcDescriptor { description: None },
+                    name: "classId".to_string(),
+                    type_name: Some("NcClassId".to_string()),
+                    is_nullable: false,
+                    is_sequence: false,
+                    constraints: None,
+                },
+                NcFieldDescriptor {
+                    base: NcDescriptor { description: None },
+                    name: "userLabel".to_string(),
+                    type_name: Some("NcString".to_string()),
+                    is_nullable: true,
+                    is_sequence: false,
+                    constraints: None,
+                },
+                NcFieldDescriptor {
+                    base: NcDescriptor { description: None },
+                    name: "owner".to_string(),
+                    type_name: Some("NcOid".to_string()),
+                    is_nullable: false,
+                    is_sequence: false,
+                    constraints: None,
+                },
+            ],
+            parent_type: Some("NcDescriptor".to_string()),
+        };
+        if include_inherited {
+            let base = NcDescriptor::get_type_descriptor(true);
+            current.fields.extend(base.fields);
+        }
+        current
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NcClassDescriptor {
+    #[serde(flatten)]
+    pub base: NcDescriptor,
+    #[serde(rename = "classId")]
+    pub class_id: Vec<u32>,
+    pub name: String,
+    #[serde(rename = "fixedRole")]
+    pub fixed_role: Option<String>,
+    pub properties: Vec<NcPropertyDescriptor>,
+    pub methods: Vec<NcMethodDescriptor>,
+    pub events: Vec<NcEventDescriptor>,
+}
+
+impl NcClassDescriptor {
+    pub fn get_type_descriptor(include_inherited: bool) -> NcDatatypeDescriptorStruct {
+        let mut current = NcDatatypeDescriptorStruct {
+            base: NcDatatypeDescriptor {
+                base: NcDescriptor {
+                    description: Some("Descriptor of a class".to_string()),
+                },
+                name: "NcClassDescriptor".to_string(),
+                type_: NcDatatypeType::Struct,
+                constraints: None,
+            },
+            fields: vec![
+                NcFieldDescriptor {
+                    base: NcDescriptor {
+                        description: Some("Numeric class identity".to_string()),
+                    },
+                    name: "classId".to_string(),
+                    type_name: Some("NcClassId".to_string()),
+                    is_nullable: false,
+                    is_sequence: false,
+                    constraints: None,
+                },
+                NcFieldDescriptor {
+                    base: NcDescriptor {
+                        description: Some("Class name".to_string()),
+                    },
+                    name: "name".to_string(),
+                    type_name: Some("NcName".to_string()),
+                    is_nullable: false,
+                    is_sequence: false,
+                    constraints: None,
+                },
+                NcFieldDescriptor {
+                    base: NcDescriptor {
+                        description: Some("Fixed role for manager classes".to_string()),
+                    },
+                    name: "fixedRole".to_string(),
+                    type_name: Some("NcString".to_string()),
+                    is_nullable: true,
+                    is_sequence: false,
+                    constraints: None,
+                },
+                NcFieldDescriptor {
+                    base: NcDescriptor {
+                        description: Some("Property descriptors".to_string()),
+                    },
+                    name: "properties".to_string(),
+                    type_name: Some("NcPropertyDescriptor".to_string()),
+                    is_nullable: false,
+                    is_sequence: true,
+                    constraints: None,
+                },
+                NcFieldDescriptor {
+                    base: NcDescriptor {
+                        description: Some("Method descriptors".to_string()),
+                    },
+                    name: "methods".to_string(),
+                    type_name: Some("NcMethodDescriptor".to_string()),
+                    is_nullable: false,
+                    is_sequence: true,
+                    constraints: None,
+                },
+                NcFieldDescriptor {
+                    base: NcDescriptor {
+                        description: Some("Event descriptors".to_string()),
+                    },
+                    name: "events".to_string(),
+                    type_name: Some("NcEventDescriptor".to_string()),
+                    is_nullable: false,
+                    is_sequence: true,
+                    constraints: None,
+                },
+            ],
+            parent_type: Some("NcDescriptor".to_string()),
+        };
+        if include_inherited {
+            let base = NcDescriptor::get_type_descriptor(true);
+            current.fields.extend(base.fields);
+        }
+        current
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(into = "u32", try_from = "u32")]
+#[repr(u32)]
+pub enum NcDatatypeType {
+    Primitive = 0,
+    Typedef = 1,
+    Struct = 2,
+    Enum = 3,
+}
+
+impl From<NcDatatypeType> for u32 {
+    fn from(v: NcDatatypeType) -> Self {
+        v as u32
+    }
+}
+
+impl From<u32> for NcDatatypeType {
+    fn from(value: u32) -> Self {
+        match value {
+            0 => NcDatatypeType::Primitive,
+            1 => NcDatatypeType::Typedef,
+            2 => NcDatatypeType::Struct,
+            3 => NcDatatypeType::Enum,
+            _ => NcDatatypeType::Primitive,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NcDatatypeDescriptor {
+    #[serde(flatten)]
+    pub base: NcDescriptor,
+    pub name: String,
+    #[serde(rename = "type")]
+    pub type_: NcDatatypeType,
+    pub constraints: Option<NcParameterConstraintsUnion>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum NcAnyDatatypeDescriptor {
+    Primitive(NcDatatypeDescriptor),
+    TypeDef(NcDatatypeDescriptorTypeDef),
+    Struct(NcDatatypeDescriptorStruct),
+    Enum(NcDatatypeDescriptorEnum),
+}
+
+impl NcDatatypeDescriptor {
+    pub fn get_type_descriptor(include_inherited: bool) -> NcDatatypeDescriptorStruct {
+        let mut current = NcDatatypeDescriptorStruct {
+            base: NcDatatypeDescriptor {
+                base: NcDescriptor {
+                    description: Some("Datatype descriptor base".to_string()),
+                },
+                name: "NcDatatypeDescriptor".to_string(),
+                type_: NcDatatypeType::Struct,
+                constraints: None,
+            },
+            fields: vec![
+                NcFieldDescriptor {
+                    base: NcDescriptor { description: None },
+                    name: "name".to_string(),
+                    type_name: Some("NcName".to_string()),
+                    is_nullable: false,
+                    is_sequence: false,
+                    constraints: None,
+                },
+                NcFieldDescriptor {
+                    base: NcDescriptor { description: None },
+                    name: "type".to_string(),
+                    type_name: Some("NcDatatypeType".to_string()),
+                    is_nullable: false,
+                    is_sequence: false,
+                    constraints: None,
+                },
+                NcFieldDescriptor {
+                    base: NcDescriptor { description: None },
+                    name: "constraints".to_string(),
+                    type_name: Some("NcParameterConstraints".to_string()),
+                    is_nullable: true,
+                    is_sequence: false,
+                    constraints: None,
+                },
+            ],
+            parent_type: Some("NcDescriptor".to_string()),
+        };
+        if include_inherited {
+            let base = NcDescriptor::get_type_descriptor(true);
+            current.fields.extend(base.fields);
+        }
+        current
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NcDatatypeDescriptorPrimitive {
+    #[serde(flatten)]
+    pub base: NcDatatypeDescriptor,
+}
+
+impl NcDatatypeDescriptorPrimitive {
+    pub fn get_type_descriptor(include_inherited: bool) -> NcDatatypeDescriptorStruct {
+        let mut current = NcDatatypeDescriptorStruct {
+            base: NcDatatypeDescriptor {
+                base: NcDescriptor {
+                    description: Some("Primitive datatype descriptor".to_string()),
+                },
+                name: "NcDatatypeDescriptorPrimitive".to_string(),
+                type_: NcDatatypeType::Struct,
+                constraints: None,
+            },
+            fields: vec![],
+            parent_type: Some("NcDatatypeDescriptor".to_string()),
+        };
+        if include_inherited {
+            let base = NcDatatypeDescriptor::get_type_descriptor(true);
+            current.fields.extend(base.fields);
+        }
+        current
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NcDatatypeDescriptorTypeDef {
+    #[serde(flatten)]
+    pub base: NcDatatypeDescriptor,
+    #[serde(rename = "parentType")]
+    pub parent_type: String,
+    #[serde(rename = "isSequence")]
+    pub is_sequence: bool,
+}
+
+impl NcDatatypeDescriptorTypeDef {
+    pub fn get_type_descriptor(include_inherited: bool) -> NcDatatypeDescriptorStruct {
+        let mut current = NcDatatypeDescriptorStruct {
+            base: NcDatatypeDescriptor {
+                base: NcDescriptor {
+                    description: Some("Typedef datatype descriptor".to_string()),
+                },
+                name: "NcDatatypeDescriptorTypeDef".to_string(),
+                type_: NcDatatypeType::Struct,
+                constraints: None,
+            },
+            fields: vec![
+                NcFieldDescriptor {
+                    base: NcDescriptor { description: None },
+                    name: "parentType".to_string(),
+                    type_name: Some("NcName".to_string()),
+                    is_nullable: false,
+                    is_sequence: false,
+                    constraints: None,
+                },
+                NcFieldDescriptor {
+                    base: NcDescriptor { description: None },
+                    name: "isSequence".to_string(),
+                    type_name: Some("NcBoolean".to_string()),
+                    is_nullable: false,
+                    is_sequence: false,
+                    constraints: None,
+                },
+            ],
+            parent_type: Some("NcDatatypeDescriptor".to_string()),
+        };
+        if include_inherited {
+            let base = NcDatatypeDescriptor::get_type_descriptor(true);
+            current.fields.extend(base.fields);
+        }
+        current
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NcDatatypeDescriptorStruct {
+    #[serde(flatten)]
+    pub base: NcDatatypeDescriptor,
+    pub fields: Vec<NcFieldDescriptor>,
+    #[serde(rename = "parentType")]
+    pub parent_type: Option<String>,
+}
+
+impl NcDatatypeDescriptorStruct {
+    pub fn get_type_descriptor(include_inherited: bool) -> NcDatatypeDescriptorStruct {
+        let mut current = NcDatatypeDescriptorStruct {
+            base: NcDatatypeDescriptor {
+                base: NcDescriptor {
+                    description: Some("Struct datatype descriptor".to_string()),
+                },
+                name: "NcDatatypeDescriptorStruct".to_string(),
+                type_: NcDatatypeType::Struct,
+                constraints: None,
+            },
+            fields: vec![
+                NcFieldDescriptor {
+                    base: NcDescriptor { description: None },
+                    name: "fields".to_string(),
+                    type_name: Some("NcFieldDescriptor".to_string()),
+                    is_nullable: false,
+                    is_sequence: true,
+                    constraints: None,
+                },
+                NcFieldDescriptor {
+                    base: NcDescriptor { description: None },
+                    name: "parentType".to_string(),
+                    type_name: Some("NcName".to_string()),
+                    is_nullable: true,
+                    is_sequence: false,
+                    constraints: None,
+                },
+            ],
+            parent_type: Some("NcDatatypeDescriptor".to_string()),
+        };
+        if include_inherited {
+            let base = NcDatatypeDescriptor::get_type_descriptor(true);
+            current.fields.extend(base.fields);
+        }
+        current
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NcDatatypeDescriptorEnum {
+    #[serde(flatten)]
+    pub base: NcDatatypeDescriptor,
+    pub items: Vec<NcEnumItemDescriptor>,
+}
+
+impl NcDatatypeDescriptorEnum {
+    pub fn get_type_descriptor(include_inherited: bool) -> NcDatatypeDescriptorStruct {
+        let mut current = NcDatatypeDescriptorStruct {
+            base: NcDatatypeDescriptor {
+                base: NcDescriptor {
+                    description: Some("Enum datatype descriptor".to_string()),
+                },
+                name: "NcDatatypeDescriptorEnum".to_string(),
+                type_: NcDatatypeType::Struct,
+                constraints: None,
+            },
+            fields: vec![NcFieldDescriptor {
+                base: NcDescriptor { description: None },
+                name: "items".to_string(),
+                type_name: Some("NcEnumItemDescriptor".to_string()),
+                is_nullable: false,
+                is_sequence: true,
+                constraints: None,
+            }],
+            parent_type: Some("NcDatatypeDescriptor".to_string()),
+        };
+        if include_inherited {
+            let base = NcDatatypeDescriptor::get_type_descriptor(true);
+            current.fields.extend(base.fields);
+        }
+        current
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NcFieldDescriptor {
+    #[serde(flatten)]
+    pub base: NcDescriptor,
+    pub name: String,
+    #[serde(rename = "typeName")]
+    pub type_name: Option<String>,
+    #[serde(rename = "isNullable")]
+    pub is_nullable: bool,
+    #[serde(rename = "isSequence")]
+    pub is_sequence: bool,
+    pub constraints: Option<NcParameterConstraintsUnion>,
+}
+
+impl NcFieldDescriptor {
+    pub fn get_type_descriptor(include_inherited: bool) -> NcDatatypeDescriptorStruct {
+        let mut current = NcDatatypeDescriptorStruct {
+            base: NcDatatypeDescriptor {
+                base: NcDescriptor {
+                    description: Some("Descriptor of a field of a struct".to_string()),
+                },
+                name: "NcFieldDescriptor".to_string(),
+                type_: NcDatatypeType::Struct,
+                constraints: None,
+            },
+            fields: vec![
+                NcFieldDescriptor {
+                    base: NcDescriptor {
+                        description: Some("Name of field".to_string()),
+                    },
+                    name: "name".to_string(),
+                    type_name: Some("NcName".to_string()),
+                    is_nullable: false,
+                    is_sequence: false,
+                    constraints: None,
+                },
+                NcFieldDescriptor {
+                    base: NcDescriptor {
+                        description: Some(
+                            "Name of field's datatype. Can only ever be null if the type is any"
+                                .to_string(),
+                        ),
+                    },
+                    name: "typeName".to_string(),
+                    type_name: Some("NcName".to_string()),
+                    is_nullable: true,
+                    is_sequence: false,
+                    constraints: None,
+                },
+                NcFieldDescriptor {
+                    base: NcDescriptor {
+                        description: Some("TRUE iff field is nullable".to_string()),
+                    },
+                    name: "isNullable".to_string(),
+                    type_name: Some("NcBoolean".to_string()),
+                    is_nullable: false,
+                    is_sequence: false,
+                    constraints: None,
+                },
+                NcFieldDescriptor {
+                    base: NcDescriptor {
+                        description: Some("TRUE iff field is a sequence".to_string()),
+                    },
+                    name: "isSequence".to_string(),
+                    type_name: Some("NcBoolean".to_string()),
+                    is_nullable: false,
+                    is_sequence: false,
+                    constraints: None,
+                },
+                NcFieldDescriptor {
+                    base: NcDescriptor {
+                        description: Some(
+                            "Optional constraints on top of the underlying data type".to_string(),
+                        ),
+                    },
+                    name: "constraints".to_string(),
+                    type_name: Some("NcParameterConstraints".to_string()),
+                    is_nullable: true,
+                    is_sequence: false,
+                    constraints: None,
+                },
+            ],
+            parent_type: Some("NcDescriptor".to_string()),
+        };
+        if include_inherited {
+            let base = NcDescriptor::get_type_descriptor(true);
+            current.fields.extend(base.fields);
+        }
+        current
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NcEnumItemDescriptor {
+    #[serde(flatten)]
+    pub base: NcDescriptor,
+    pub name: String,
+    pub value: u16,
+}
+
+impl NcEnumItemDescriptor {
+    pub fn get_type_descriptor(include_inherited: bool) -> NcDatatypeDescriptorStruct {
+        let mut current = NcDatatypeDescriptorStruct {
+            base: NcDatatypeDescriptor {
+                base: NcDescriptor {
+                    description: Some("Descriptor of an enum item".to_string()),
+                },
+                name: "NcEnumItemDescriptor".to_string(),
+                type_: NcDatatypeType::Struct,
+                constraints: None,
+            },
+            fields: vec![
+                NcFieldDescriptor {
+                    base: NcDescriptor {
+                        description: Some("Name of option".to_string()),
+                    },
+                    name: "name".to_string(),
+                    type_name: Some("NcName".to_string()),
+                    is_nullable: false,
+                    is_sequence: false,
+                    constraints: None,
+                },
+                NcFieldDescriptor {
+                    base: NcDescriptor {
+                        description: Some("Enum item numerical value".to_string()),
+                    },
+                    name: "value".to_string(),
+                    type_name: Some("NcUint16".to_string()),
+                    is_nullable: false,
+                    is_sequence: false,
+                    constraints: None,
+                },
+            ],
+            parent_type: Some("NcDescriptor".to_string()),
+        };
+        if include_inherited {
+            let base = NcDescriptor::get_type_descriptor(true);
+            current.fields.extend(base.fields);
+        }
+        current
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NcEventDescriptor {
+    #[serde(flatten)]
+    pub base: NcDescriptor,
+    pub id: NcElementId,
+    pub name: String,
+    #[serde(rename = "eventDatatype")]
+    pub event_datatype: String,
+    #[serde(rename = "isDeprecated")]
+    pub is_deprecated: bool,
+}
+
+impl NcEventDescriptor {
+    pub fn get_type_descriptor(include_inherited: bool) -> NcDatatypeDescriptorStruct {
+        let mut current = NcDatatypeDescriptorStruct {
+            base: NcDatatypeDescriptor {
+                base: NcDescriptor {
+                    description: Some("Descriptor of an event".to_string()),
+                },
+                name: "NcEventDescriptor".to_string(),
+                type_: NcDatatypeType::Struct,
+                constraints: None,
+            },
+            fields: vec![
+                NcFieldDescriptor {
+                    base: NcDescriptor { description: None },
+                    name: "id".to_string(),
+                    type_name: Some("NcEventId".to_string()),
+                    is_nullable: false,
+                    is_sequence: false,
+                    constraints: None,
+                },
+                NcFieldDescriptor {
+                    base: NcDescriptor { description: None },
+                    name: "name".to_string(),
+                    type_name: Some("NcName".to_string()),
+                    is_nullable: false,
+                    is_sequence: false,
+                    constraints: None,
+                },
+                NcFieldDescriptor {
+                    base: NcDescriptor { description: None },
+                    name: "eventDatatype".to_string(),
+                    type_name: Some("NcName".to_string()),
+                    is_nullable: false,
+                    is_sequence: false,
+                    constraints: None,
+                },
+                NcFieldDescriptor {
+                    base: NcDescriptor { description: None },
+                    name: "isDeprecated".to_string(),
+                    type_name: Some("NcBoolean".to_string()),
+                    is_nullable: false,
+                    is_sequence: false,
+                    constraints: None,
+                },
+            ],
+            parent_type: Some("NcDescriptor".to_string()),
+        };
+        if include_inherited {
+            let base = NcDescriptor::get_type_descriptor(true);
+            current.fields.extend(base.fields);
+        }
+        current
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NcMethodDescriptor {
+    #[serde(flatten)]
+    pub base: NcDescriptor,
+    pub id: NcElementId,
+    pub name: String,
+    #[serde(rename = "resultDatatype")]
+    pub result_datatype: String,
+    pub parameters: Vec<NcParameterDescriptor>,
+    #[serde(rename = "isDeprecated")]
+    pub is_deprecated: bool,
+}
+
+impl NcMethodDescriptor {
+    pub fn get_type_descriptor(include_inherited: bool) -> NcDatatypeDescriptorStruct {
+        let mut current = NcDatatypeDescriptorStruct {
+            base: NcDatatypeDescriptor {
+                base: NcDescriptor {
+                    description: Some("Descriptor of a method".to_string()),
+                },
+                name: "NcMethodDescriptor".to_string(),
+                type_: NcDatatypeType::Struct,
+                constraints: None,
+            },
+            fields: vec![
+                NcFieldDescriptor {
+                    base: NcDescriptor { description: None },
+                    name: "id".to_string(),
+                    type_name: Some("NcMethodId".to_string()),
+                    is_nullable: false,
+                    is_sequence: false,
+                    constraints: None,
+                },
+                NcFieldDescriptor {
+                    base: NcDescriptor { description: None },
+                    name: "name".to_string(),
+                    type_name: Some("NcName".to_string()),
+                    is_nullable: false,
+                    is_sequence: false,
+                    constraints: None,
+                },
+                NcFieldDescriptor {
+                    base: NcDescriptor { description: None },
+                    name: "resultDatatype".to_string(),
+                    type_name: Some("NcName".to_string()),
+                    is_nullable: false,
+                    is_sequence: false,
+                    constraints: None,
+                },
+                NcFieldDescriptor {
+                    base: NcDescriptor { description: None },
+                    name: "parameters".to_string(),
+                    type_name: Some("NcParameterDescriptor".to_string()),
+                    is_nullable: false,
+                    is_sequence: true,
+                    constraints: None,
+                },
+                NcFieldDescriptor {
+                    base: NcDescriptor { description: None },
+                    name: "isDeprecated".to_string(),
+                    type_name: Some("NcBoolean".to_string()),
+                    is_nullable: false,
+                    is_sequence: false,
+                    constraints: None,
+                },
+            ],
+            parent_type: Some("NcDescriptor".to_string()),
+        };
+        if include_inherited {
+            let base = NcDescriptor::get_type_descriptor(true);
+            current.fields.extend(base.fields);
+        }
+        current
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NcParameterDescriptor {
+    #[serde(flatten)]
+    pub base: NcDescriptor,
+    pub name: String,
+    #[serde(rename = "typeName")]
+    pub type_name: Option<String>,
+    #[serde(rename = "isNullable")]
+    pub is_nullable: bool,
+    #[serde(rename = "isSequence")]
+    pub is_sequence: bool,
+    pub constraints: Option<NcParameterConstraintsUnion>,
+}
+
+impl NcParameterDescriptor {
+    pub fn get_type_descriptor(include_inherited: bool) -> NcDatatypeDescriptorStruct {
+        let mut current = NcDatatypeDescriptorStruct {
+            base: NcDatatypeDescriptor {
+                base: NcDescriptor {
+                    description: Some("Descriptor of a method parameter".to_string()),
+                },
+                name: "NcParameterDescriptor".to_string(),
+                type_: NcDatatypeType::Struct,
+                constraints: None,
+            },
+            fields: vec![
+                NcFieldDescriptor {
+                    base: NcDescriptor { description: None },
+                    name: "name".to_string(),
+                    type_name: Some("NcName".to_string()),
+                    is_nullable: false,
+                    is_sequence: false,
+                    constraints: None,
+                },
+                NcFieldDescriptor {
+                    base: NcDescriptor { description: None },
+                    name: "typeName".to_string(),
+                    type_name: Some("NcName".to_string()),
+                    is_nullable: true,
+                    is_sequence: false,
+                    constraints: None,
+                },
+                NcFieldDescriptor {
+                    base: NcDescriptor { description: None },
+                    name: "isNullable".to_string(),
+                    type_name: Some("NcBoolean".to_string()),
+                    is_nullable: false,
+                    is_sequence: false,
+                    constraints: None,
+                },
+                NcFieldDescriptor {
+                    base: NcDescriptor { description: None },
+                    name: "isSequence".to_string(),
+                    type_name: Some("NcBoolean".to_string()),
+                    is_nullable: false,
+                    is_sequence: false,
+                    constraints: None,
+                },
+                NcFieldDescriptor {
+                    base: NcDescriptor { description: None },
+                    name: "constraints".to_string(),
+                    type_name: Some("NcParameterConstraints".to_string()),
+                    is_nullable: true,
+                    is_sequence: false,
+                    constraints: None,
+                },
+            ],
+            parent_type: Some("NcDescriptor".to_string()),
+        };
+        if include_inherited {
+            let base = NcDescriptor::get_type_descriptor(true);
+            current.fields.extend(base.fields);
+        }
+        current
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NcPropertyDescriptor {
+    #[serde(flatten)]
+    pub base: NcDescriptor,
+    pub id: NcElementId,
+    pub name: String,
+    #[serde(rename = "typeName")]
+    pub type_name: Option<String>,
+    #[serde(rename = "isReadOnly")]
+    pub is_read_only: bool,
+    #[serde(rename = "isNullable")]
+    pub is_nullable: bool,
+    #[serde(rename = "isSequence")]
+    pub is_sequence: bool,
+    #[serde(rename = "isDeprecated")]
+    pub is_deprecated: bool,
+    pub constraints: Option<NcParameterConstraintsUnion>,
+}
+
+impl NcPropertyDescriptor {
+    pub fn get_type_descriptor(include_inherited: bool) -> NcDatatypeDescriptorStruct {
+        let mut current = NcDatatypeDescriptorStruct {
+            base: NcDatatypeDescriptor {
+                base: NcDescriptor {
+                    description: Some("Descriptor of a property".to_string()),
+                },
+                name: "NcPropertyDescriptor".to_string(),
+                type_: NcDatatypeType::Struct,
+                constraints: None,
+            },
+            fields: vec![
+                NcFieldDescriptor {
+                    base: NcDescriptor { description: None },
+                    name: "id".to_string(),
+                    type_name: Some("NcPropertyId".to_string()),
+                    is_nullable: false,
+                    is_sequence: false,
+                    constraints: None,
+                },
+                NcFieldDescriptor {
+                    base: NcDescriptor { description: None },
+                    name: "name".to_string(),
+                    type_name: Some("NcName".to_string()),
+                    is_nullable: false,
+                    is_sequence: false,
+                    constraints: None,
+                },
+                NcFieldDescriptor {
+                    base: NcDescriptor { description: None },
+                    name: "typeName".to_string(),
+                    type_name: Some("NcName".to_string()),
+                    is_nullable: true,
+                    is_sequence: false,
+                    constraints: None,
+                },
+                NcFieldDescriptor {
+                    base: NcDescriptor { description: None },
+                    name: "isReadOnly".to_string(),
+                    type_name: Some("NcBoolean".to_string()),
+                    is_nullable: false,
+                    is_sequence: false,
+                    constraints: None,
+                },
+                NcFieldDescriptor {
+                    base: NcDescriptor { description: None },
+                    name: "isNullable".to_string(),
+                    type_name: Some("NcBoolean".to_string()),
+                    is_nullable: false,
+                    is_sequence: false,
+                    constraints: None,
+                },
+                NcFieldDescriptor {
+                    base: NcDescriptor { description: None },
+                    name: "isSequence".to_string(),
+                    type_name: Some("NcBoolean".to_string()),
+                    is_nullable: false,
+                    is_sequence: false,
+                    constraints: None,
+                },
+                NcFieldDescriptor {
+                    base: NcDescriptor { description: None },
+                    name: "isDeprecated".to_string(),
+                    type_name: Some("NcBoolean".to_string()),
+                    is_nullable: false,
+                    is_sequence: false,
+                    constraints: None,
+                },
+                NcFieldDescriptor {
+                    base: NcDescriptor { description: None },
+                    name: "constraints".to_string(),
+                    type_name: Some("NcParameterConstraints".to_string()),
+                    is_nullable: true,
+                    is_sequence: false,
+                    constraints: None,
+                },
+            ],
+            parent_type: Some("NcDescriptor".to_string()),
+        };
+        if include_inherited {
+            let base = NcDescriptor::get_type_descriptor(true);
+            current.fields.extend(base.fields);
+        }
+        current
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum NcParameterConstraintsUnion {
+    Number(NcParameterConstraintsNumber),
+    String(NcParameterConstraintsString),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NcParameterConstraints {
+    #[serde(rename = "defaultValue")]
+    pub default_value: Option<Value>,
+}
+
+impl NcParameterConstraints {
+    pub fn get_type_descriptor(_include_inherited: bool) -> NcDatatypeDescriptorStruct {
+        NcDatatypeDescriptorStruct {
+            base: NcDatatypeDescriptor {
+                base: NcDescriptor {
+                    description: Some("Base parameter constraints".to_string()),
+                },
+                name: "NcParameterConstraints".to_string(),
+                type_: NcDatatypeType::Struct,
+                constraints: None,
+            },
+            fields: vec![NcFieldDescriptor {
+                base: NcDescriptor { description: None },
+                name: "defaultValue".to_string(),
+                type_name: None,
+                is_nullable: true,
+                is_sequence: false,
+                constraints: None,
+            }],
+            parent_type: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NcParameterConstraintsNumber {
+    #[serde(flatten)]
+    pub base: NcParameterConstraints,
+    pub maximum: Option<f64>,
+    pub minimum: Option<f64>,
+    pub step: Option<f64>,
+}
+
+impl NcParameterConstraintsNumber {
+    pub fn get_type_descriptor(include_inherited: bool) -> NcDatatypeDescriptorStruct {
+        let mut current = NcDatatypeDescriptorStruct {
+            base: NcDatatypeDescriptor {
+                base: NcDescriptor {
+                    description: Some("Numeric parameter constraints".to_string()),
+                },
+                name: "NcParameterConstraintsNumber".to_string(),
+                type_: NcDatatypeType::Struct,
+                constraints: None,
+            },
+            fields: vec![
+                NcFieldDescriptor {
+                    base: NcDescriptor { description: None },
+                    name: "maximum".to_string(),
+                    type_name: None,
+                    is_nullable: true,
+                    is_sequence: false,
+                    constraints: None,
+                },
+                NcFieldDescriptor {
+                    base: NcDescriptor { description: None },
+                    name: "minimum".to_string(),
+                    type_name: None,
+                    is_nullable: true,
+                    is_sequence: false,
+                    constraints: None,
+                },
+                NcFieldDescriptor {
+                    base: NcDescriptor { description: None },
+                    name: "step".to_string(),
+                    type_name: None,
+                    is_nullable: true,
+                    is_sequence: false,
+                    constraints: None,
+                },
+            ],
+            parent_type: Some("NcParameterConstraints".to_string()),
+        };
+        if include_inherited {
+            let base = NcParameterConstraints::get_type_descriptor(true);
+            current.fields.extend(base.fields);
+        }
+        current
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NcParameterConstraintsString {
+    #[serde(flatten)]
+    pub base: NcParameterConstraints,
+    #[serde(rename = "maxCharacters")]
+    pub max_characters: Option<u32>,
+    pub pattern: Option<String>,
+}
+
+impl NcParameterConstraintsString {
+    pub fn get_type_descriptor(include_inherited: bool) -> NcDatatypeDescriptorStruct {
+        let mut current = NcDatatypeDescriptorStruct {
+            base: NcDatatypeDescriptor {
+                base: NcDescriptor {
+                    description: Some("String parameter constraints".to_string()),
+                },
+                name: "NcParameterConstraintsString".to_string(),
+                type_: NcDatatypeType::Struct,
+                constraints: None,
+            },
+            fields: vec![
+                NcFieldDescriptor {
+                    base: NcDescriptor { description: None },
+                    name: "maxCharacters".to_string(),
+                    type_name: Some("NcUint32".to_string()),
+                    is_nullable: true,
+                    is_sequence: false,
+                    constraints: None,
+                },
+                NcFieldDescriptor {
+                    base: NcDescriptor { description: None },
+                    name: "pattern".to_string(),
+                    type_name: Some("NcRegex".to_string()),
+                    is_nullable: true,
+                    is_sequence: false,
+                    constraints: None,
+                },
+            ],
+            parent_type: Some("NcParameterConstraints".to_string()),
+        };
+        if include_inherited {
+            let base = NcParameterConstraints::get_type_descriptor(true);
+            current.fields.extend(base.fields);
+        }
+        current
+    }
+}
+
 #[derive(Serialize, Deserialize, Clone, Debug)]
-pub struct ElementId {
+pub struct NcElementId {
     pub level: u32,
     pub index: u32,
+}
+
+impl NcElementId {
+    pub fn get_type_descriptor(_include_inherited: bool) -> NcDatatypeDescriptorStruct {
+        NcDatatypeDescriptorStruct {
+            base: NcDatatypeDescriptor {
+                base: NcDescriptor {
+                    description: Some("Element identifier".to_string()),
+                },
+                name: "NcElementId".to_string(),
+                type_: NcDatatypeType::Struct,
+                constraints: None,
+            },
+            fields: vec![
+                NcFieldDescriptor {
+                    base: NcDescriptor { description: None },
+                    name: "level".to_string(),
+                    type_name: Some("NcUint16".to_string()),
+                    is_nullable: false,
+                    is_sequence: false,
+                    constraints: None,
+                },
+                NcFieldDescriptor {
+                    base: NcDescriptor { description: None },
+                    name: "index".to_string(),
+                    type_name: Some("NcUint16".to_string()),
+                    is_nullable: false,
+                    is_sequence: false,
+                    constraints: None,
+                },
+            ],
+            parent_type: None,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct NcPropertyId {
+    pub level: u32,
+    pub index: u32,
+}
+
+impl NcPropertyId {
+    pub fn get_type_descriptor(include_inherited: bool) -> NcDatatypeDescriptorStruct {
+        let mut current = NcDatatypeDescriptorStruct {
+            base: NcDatatypeDescriptor {
+                base: NcDescriptor {
+                    description: Some("Property identifier".to_string()),
+                },
+                name: "NcPropertyId".to_string(),
+                type_: NcDatatypeType::Struct,
+                constraints: None,
+            },
+            fields: vec![],
+            parent_type: Some("NcElementId".to_string()),
+        };
+        if include_inherited {
+            let base = NcElementId::get_type_descriptor(true);
+            current.fields.extend(base.fields);
+        }
+        current
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct NcMethodId {
+    pub level: u32,
+    pub index: u32,
+}
+
+impl NcMethodId {
+    pub fn get_type_descriptor(include_inherited: bool) -> NcDatatypeDescriptorStruct {
+        let mut current = NcDatatypeDescriptorStruct {
+            base: NcDatatypeDescriptor {
+                base: NcDescriptor {
+                    description: Some("Method identifier".to_string()),
+                },
+                name: "NcMethodId".to_string(),
+                type_: NcDatatypeType::Struct,
+                constraints: None,
+            },
+            fields: vec![],
+            parent_type: Some("NcElementId".to_string()),
+        };
+        if include_inherited {
+            let base = NcElementId::get_type_descriptor(true);
+            current.fields.extend(base.fields);
+        }
+        current
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct NcEventId {
+    pub level: u32,
+    pub index: u32,
+}
+
+impl NcEventId {
+    pub fn get_type_descriptor(include_inherited: bool) -> NcDatatypeDescriptorStruct {
+        let mut current = NcDatatypeDescriptorStruct {
+            base: NcDatatypeDescriptor {
+                base: NcDescriptor {
+                    description: Some("Event identifier".to_string()),
+                },
+                name: "NcEventId".to_string(),
+                type_: NcDatatypeType::Struct,
+                constraints: None,
+            },
+            fields: vec![],
+            parent_type: Some("NcElementId".to_string()),
+        };
+        if include_inherited {
+            let base = NcElementId::get_type_descriptor(true);
+            current.fields.extend(base.fields);
+        }
+        current
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NcManufacturer {
+    pub name: String,
+    #[serde(rename = "organizationId")]
+    pub organization_id: Option<i32>,
+    pub website: Option<String>,
+}
+
+impl NcManufacturer {
+    pub fn get_type_descriptor(_include_inherited: bool) -> NcDatatypeDescriptorStruct {
+        NcDatatypeDescriptorStruct {
+            base: NcDatatypeDescriptor {
+                base: NcDescriptor {
+                    description: Some("Manufacturer descriptor".to_string()),
+                },
+                name: "NcManufacturer".to_string(),
+                type_: NcDatatypeType::Struct,
+                constraints: None,
+            },
+            fields: vec![
+                NcFieldDescriptor {
+                    base: NcDescriptor { description: None },
+                    name: "name".to_string(),
+                    type_name: Some("NcString".to_string()),
+                    is_nullable: false,
+                    is_sequence: false,
+                    constraints: None,
+                },
+                NcFieldDescriptor {
+                    base: NcDescriptor { description: None },
+                    name: "organizationId".to_string(),
+                    type_name: Some("NcOrganizationId".to_string()),
+                    is_nullable: true,
+                    is_sequence: false,
+                    constraints: None,
+                },
+                NcFieldDescriptor {
+                    base: NcDescriptor { description: None },
+                    name: "website".to_string(),
+                    type_name: Some("NcUri".to_string()),
+                    is_nullable: true,
+                    is_sequence: false,
+                    constraints: None,
+                },
+            ],
+            parent_type: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NcProduct {
+    pub name: String,
+    pub key: String,
+    #[serde(rename = "revisionLevel")]
+    pub revision_level: String,
+    #[serde(rename = "brandName")]
+    pub brand_name: Option<String>,
+    pub uuid: Option<String>,
+    pub description: Option<String>,
+}
+
+impl NcProduct {
+    pub fn get_type_descriptor(_include_inherited: bool) -> NcDatatypeDescriptorStruct {
+        NcDatatypeDescriptorStruct {
+            base: NcDatatypeDescriptor {
+                base: NcDescriptor {
+                    description: Some("Product descriptor".to_string()),
+                },
+                name: "NcProduct".to_string(),
+                type_: NcDatatypeType::Struct,
+                constraints: None,
+            },
+            fields: vec![
+                NcFieldDescriptor {
+                    base: NcDescriptor { description: None },
+                    name: "name".to_string(),
+                    type_name: Some("NcString".to_string()),
+                    is_nullable: false,
+                    is_sequence: false,
+                    constraints: None,
+                },
+                NcFieldDescriptor {
+                    base: NcDescriptor { description: None },
+                    name: "key".to_string(),
+                    type_name: Some("NcString".to_string()),
+                    is_nullable: false,
+                    is_sequence: false,
+                    constraints: None,
+                },
+                NcFieldDescriptor {
+                    base: NcDescriptor { description: None },
+                    name: "revisionLevel".to_string(),
+                    type_name: Some("NcString".to_string()),
+                    is_nullable: false,
+                    is_sequence: false,
+                    constraints: None,
+                },
+                NcFieldDescriptor {
+                    base: NcDescriptor { description: None },
+                    name: "brandName".to_string(),
+                    type_name: Some("NcString".to_string()),
+                    is_nullable: true,
+                    is_sequence: false,
+                    constraints: None,
+                },
+                NcFieldDescriptor {
+                    base: NcDescriptor { description: None },
+                    name: "uuid".to_string(),
+                    type_name: Some("NcUuid".to_string()),
+                    is_nullable: true,
+                    is_sequence: false,
+                    constraints: None,
+                },
+                NcFieldDescriptor {
+                    base: NcDescriptor { description: None },
+                    name: "description".to_string(),
+                    type_name: Some("NcString".to_string()),
+                    is_nullable: true,
+                    is_sequence: false,
+                    constraints: None,
+                },
+            ],
+            parent_type: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NcDeviceOperationalState {
+    pub generic: NcDeviceGenericState,
+    #[serde(rename = "deviceSpecificDetails")]
+    pub device_specific_details: Option<String>,
+}
+
+impl NcDeviceOperationalState {
+    pub fn get_type_descriptor(_include_inherited: bool) -> NcDatatypeDescriptorStruct {
+        NcDatatypeDescriptorStruct {
+            base: NcDatatypeDescriptor {
+                base: NcDescriptor {
+                    description: Some("Device operational state".to_string()),
+                },
+                name: "NcDeviceOperationalState".to_string(),
+                type_: NcDatatypeType::Struct,
+                constraints: None,
+            },
+            fields: vec![
+                NcFieldDescriptor {
+                    base: NcDescriptor { description: None },
+                    name: "generic".to_string(),
+                    type_name: Some("NcDeviceGenericState".to_string()),
+                    is_nullable: false,
+                    is_sequence: false,
+                    constraints: None,
+                },
+                NcFieldDescriptor {
+                    base: NcDescriptor { description: None },
+                    name: "deviceSpecificDetails".to_string(),
+                    type_name: Some("NcString".to_string()),
+                    is_nullable: true,
+                    is_sequence: false,
+                    constraints: None,
+                },
+            ],
+            parent_type: None,
+        }
+    }
+}
+
+#[derive(Serialize, Debug, Clone)]
+pub struct PropertyChangedEvent {
+    pub oid: u64,
+    #[serde(rename = "eventId")]
+    pub event_id_: NcElementId,
+    #[serde(rename = "eventData")]
+    pub event_data: PropertyChangedEventData,
+}
+
+impl PropertyChangedEvent {
+    pub fn new(oid: u64, event_data: PropertyChangedEventData) -> Self {
+        PropertyChangedEvent {
+            oid,
+            event_id_: NcElementId { level: 1, index: 1 },
+            event_data,
+        }
+    }
+}
+
+#[derive(Serialize, Debug, Clone)]
+pub struct PropertyChangedEventData {
+    #[serde(rename = "propertyId")]
+    pub property_id: NcElementId,
+    #[serde(rename = "changeType")]
+    pub change_type: NcPropertyChangeType,
+    pub value: Value,
+    #[serde(rename = "sequenceItemIndex")]
+    pub sequence_item_index: Option<u64>,
+}
+
+impl PropertyChangedEventData {
+    pub fn get_type_descriptor(_include_inherited: bool) -> NcDatatypeDescriptorStruct {
+        NcDatatypeDescriptorStruct {
+            base: NcDatatypeDescriptor {
+                base: NcDescriptor {
+                    description: Some("Property changed event data".to_string()),
+                },
+                name: "NcPropertyChangedEventData".to_string(),
+                type_: NcDatatypeType::Struct,
+                constraints: None,
+            },
+            fields: vec![
+                NcFieldDescriptor {
+                    base: NcDescriptor { description: None },
+                    name: "propertyId".to_string(),
+                    type_name: Some("NcPropertyId".to_string()),
+                    is_nullable: false,
+                    is_sequence: false,
+                    constraints: None,
+                },
+                NcFieldDescriptor {
+                    base: NcDescriptor { description: None },
+                    name: "changeType".to_string(),
+                    type_name: Some("NcPropertyChangeType".to_string()),
+                    is_nullable: false,
+                    is_sequence: false,
+                    constraints: None,
+                },
+                NcFieldDescriptor {
+                    base: NcDescriptor { description: None },
+                    name: "value".to_string(),
+                    type_name: None,
+                    is_nullable: true,
+                    is_sequence: false,
+                    constraints: None,
+                },
+                NcFieldDescriptor {
+                    base: NcDescriptor { description: None },
+                    name: "sequenceItemIndex".to_string(),
+                    type_name: Some("NcId".to_string()),
+                    is_nullable: true,
+                    is_sequence: false,
+                    constraints: None,
+                },
+            ],
+            parent_type: None,
+        }
+    }
+}
+
+impl From<NcMethodStatus> for u16 {
+    fn from(status: NcMethodStatus) -> Self {
+        status as u16
+    }
+}
+
+impl From<u16> for NcMethodStatus {
+    fn from(value: u16) -> Self {
+        match value {
+            200 => NcMethodStatus::Ok,
+            298 => NcMethodStatus::PropertyDeprecated,
+            299 => NcMethodStatus::MethodDeprecated,
+            400 => NcMethodStatus::BadCommandFormat,
+            401 => NcMethodStatus::Unauthorized,
+            404 => NcMethodStatus::BadOid,
+            405 => NcMethodStatus::Readonly,
+            406 => NcMethodStatus::InvalidRequest,
+            409 => NcMethodStatus::Conflict,
+            413 => NcMethodStatus::BufferOverflow,
+            414 => NcMethodStatus::IndexOutOfBounds,
+            417 => NcMethodStatus::ParameterError,
+            423 => NcMethodStatus::Locked,
+            500 => NcMethodStatus::DeviceError,
+            501 => NcMethodStatus::MethodNotImplemented,
+            502 => NcMethodStatus::PropertyNotImplemented,
+            503 => NcMethodStatus::NotReady,
+            504 => NcMethodStatus::Timeout,
+            _ => NcMethodStatus::DeviceError,
+        }
+    }
 }
 
 #[derive(Deserialize, Debug)]
@@ -209,18 +1867,18 @@ pub struct Command {
     pub handle: u64,
     pub oid: u64,
     #[serde(rename = "methodId")]
-    pub method_id: ElementId,
+    pub method_id: NcElementId,
     pub arguments: Value,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct IdArgs {
-    pub id: ElementId,
+    pub id: NcElementId,
 }
 
 #[derive(Deserialize, Debug)]
 pub struct IdArgsValue {
-    pub id: ElementId,
+    pub id: NcElementId,
     pub value: Value,
 }
 
@@ -232,30 +1890,296 @@ pub struct WsCommandMessage {
 }
 
 #[derive(Serialize, Debug)]
-pub struct ResponseBase {
+pub struct NcMethodResult {
     pub status: NcMethodStatus,
 }
 
-#[derive(Serialize, Debug)]
-pub struct ResponseResult {
-    #[serde(flatten)]
-    pub base: ResponseBase,
-    pub value: Value,
+impl NcMethodResult {
+    pub fn get_type_descriptor(_include_inherited: bool) -> NcDatatypeDescriptorStruct {
+        NcDatatypeDescriptorStruct {
+            base: NcDatatypeDescriptor {
+                base: NcDescriptor {
+                    description: Some("Method result base".to_string()),
+                },
+                name: "NcMethodResult".to_string(),
+                type_: NcDatatypeType::Struct,
+                constraints: None,
+            },
+            fields: vec![NcFieldDescriptor {
+                base: NcDescriptor { description: None },
+                name: "status".to_string(),
+                type_name: Some("NcMethodStatus".to_string()),
+                is_nullable: false,
+                is_sequence: false,
+                constraints: None,
+            }],
+            parent_type: None,
+        }
+    }
 }
 
 #[derive(Serialize, Debug)]
-pub struct ResponseError {
+pub struct NcMethodResultPropertyValue {
     #[serde(flatten)]
-    pub base: ResponseBase,
+    pub base: NcMethodResult,
+    pub value: Value,
+}
+
+impl NcMethodResultPropertyValue {
+    pub fn get_type_descriptor(include_inherited: bool) -> NcDatatypeDescriptorStruct {
+        let mut current = NcDatatypeDescriptorStruct {
+            base: NcDatatypeDescriptor {
+                base: NcDescriptor {
+                    description: Some("Method result with property value".to_string()),
+                },
+                name: "NcMethodResultPropertyValue".to_string(),
+                type_: NcDatatypeType::Struct,
+                constraints: None,
+            },
+            fields: vec![NcFieldDescriptor {
+                base: NcDescriptor { description: None },
+                name: "value".to_string(),
+                type_name: None,
+                is_nullable: true,
+                is_sequence: false,
+                constraints: None,
+            }],
+            parent_type: Some("NcMethodResult".to_string()),
+        };
+        if include_inherited {
+            let base = NcMethodResult::get_type_descriptor(true);
+            current.fields.extend(base.fields);
+        }
+        current
+    }
+}
+
+#[derive(Serialize, Debug)]
+pub struct NcMethodResultBlockMemberDescriptors {
+    #[serde(flatten)]
+    pub base: NcMethodResult,
+    pub value: Vec<NcBlockMemberDescriptor>,
+}
+
+impl NcMethodResultBlockMemberDescriptors {
+    pub fn get_type_descriptor(include_inherited: bool) -> NcDatatypeDescriptorStruct {
+        let mut current = NcDatatypeDescriptorStruct {
+            base: NcDatatypeDescriptor {
+                base: NcDescriptor {
+                    description: Some(
+                        "Method result containing block member descriptors".to_string(),
+                    ),
+                },
+                name: "NcMethodResultBlockMemberDescriptors".to_string(),
+                type_: NcDatatypeType::Struct,
+                constraints: None,
+            },
+            fields: vec![NcFieldDescriptor {
+                base: NcDescriptor { description: None },
+                name: "value".to_string(),
+                type_name: Some("NcBlockMemberDescriptor".to_string()),
+                is_nullable: false,
+                is_sequence: true,
+                constraints: None,
+            }],
+            parent_type: Some("NcMethodResult".to_string()),
+        };
+        if include_inherited {
+            let base = NcMethodResult::get_type_descriptor(true);
+            current.fields.extend(base.fields);
+        }
+        current
+    }
+}
+
+#[derive(Serialize, Debug)]
+pub struct NcMethodResultClassDescriptor {
+    #[serde(flatten)]
+    pub base: NcMethodResult,
+    pub value: NcClassDescriptor,
+}
+
+impl NcMethodResultClassDescriptor {
+    pub fn get_type_descriptor(include_inherited: bool) -> NcDatatypeDescriptorStruct {
+        let mut current = NcDatatypeDescriptorStruct {
+            base: NcDatatypeDescriptor {
+                base: NcDescriptor {
+                    description: Some("Method result containing a class descriptor".to_string()),
+                },
+                name: "NcMethodResultClassDescriptor".to_string(),
+                type_: NcDatatypeType::Struct,
+                constraints: None,
+            },
+            fields: vec![NcFieldDescriptor {
+                base: NcDescriptor { description: None },
+                name: "value".to_string(),
+                type_name: Some("NcClassDescriptor".to_string()),
+                is_nullable: false,
+                is_sequence: false,
+                constraints: None,
+            }],
+            parent_type: Some("NcMethodResult".to_string()),
+        };
+        if include_inherited {
+            let base = NcMethodResult::get_type_descriptor(true);
+            current.fields.extend(base.fields);
+        }
+        current
+    }
+}
+
+#[derive(Serialize, Debug)]
+pub struct NcMethodResultDatatypeDescriptor {
+    #[serde(flatten)]
+    pub base: NcMethodResult,
+    pub value: NcDatatypeDescriptor,
+}
+
+impl NcMethodResultDatatypeDescriptor {
+    pub fn get_type_descriptor(include_inherited: bool) -> NcDatatypeDescriptorStruct {
+        let mut current = NcDatatypeDescriptorStruct {
+            base: NcDatatypeDescriptor {
+                base: NcDescriptor {
+                    description: Some("Method result containing a datatype descriptor".to_string()),
+                },
+                name: "NcMethodResultDatatypeDescriptor".to_string(),
+                type_: NcDatatypeType::Struct,
+                constraints: None,
+            },
+            fields: vec![NcFieldDescriptor {
+                base: NcDescriptor { description: None },
+                name: "value".to_string(),
+                type_name: Some("NcDatatypeDescriptor".to_string()),
+                is_nullable: false,
+                is_sequence: false,
+                constraints: None,
+            }],
+            parent_type: Some("NcMethodResult".to_string()),
+        };
+        if include_inherited {
+            let base = NcMethodResult::get_type_descriptor(true);
+            current.fields.extend(base.fields);
+        }
+        current
+    }
+}
+
+#[derive(Serialize, Debug)]
+pub struct NcMethodResultId {
+    #[serde(flatten)]
+    pub base: NcMethodResult,
+    #[serde(rename = "value")]
+    pub value: u64,
+}
+
+impl NcMethodResultId {
+    pub fn get_type_descriptor(include_inherited: bool) -> NcDatatypeDescriptorStruct {
+        let mut current = NcDatatypeDescriptorStruct {
+            base: NcDatatypeDescriptor {
+                base: NcDescriptor {
+                    description: Some("Id method result".to_string()),
+                },
+                name: "NcMethodResultId".to_string(),
+                type_: NcDatatypeType::Struct,
+                constraints: None,
+            },
+            fields: vec![NcFieldDescriptor {
+                base: NcDescriptor { description: None },
+                name: "value".to_string(),
+                type_name: Some("NcId".to_string()),
+                is_nullable: false,
+                is_sequence: false,
+                constraints: None,
+            }],
+            parent_type: Some("NcMethodResult".to_string()),
+        };
+        if include_inherited {
+            let base = NcMethodResult::get_type_descriptor(true);
+            current.fields.extend(base.fields);
+        }
+        current
+    }
+}
+
+#[derive(Serialize, Debug)]
+pub struct NcMethodResultLength {
+    #[serde(flatten)]
+    pub base: NcMethodResult,
+    #[serde(rename = "value")]
+    pub value: Option<u32>,
+}
+
+impl NcMethodResultLength {
+    pub fn get_type_descriptor(include_inherited: bool) -> NcDatatypeDescriptorStruct {
+        let mut current = NcDatatypeDescriptorStruct {
+            base: NcDatatypeDescriptor {
+                base: NcDescriptor {
+                    description: Some("Length method result".to_string()),
+                },
+                name: "NcMethodResultLength".to_string(),
+                type_: NcDatatypeType::Struct,
+                constraints: None,
+            },
+            fields: vec![NcFieldDescriptor {
+                base: NcDescriptor { description: None },
+                name: "value".to_string(),
+                type_name: Some("NcUint32".to_string()),
+                is_nullable: true,
+                is_sequence: false,
+                constraints: None,
+            }],
+            parent_type: Some("NcMethodResult".to_string()),
+        };
+        if include_inherited {
+            let base = NcMethodResult::get_type_descriptor(true);
+            current.fields.extend(base.fields);
+        }
+        current
+    }
+}
+
+#[derive(Serialize, Debug)]
+pub struct NcMethodResultError {
+    #[serde(flatten)]
+    pub base: NcMethodResult,
     #[serde(rename = "errorMessage")]
     pub error_message: Option<String>,
+}
+
+impl NcMethodResultError {
+    pub fn get_type_descriptor(include_inherited: bool) -> NcDatatypeDescriptorStruct {
+        let mut current = NcDatatypeDescriptorStruct {
+            base: NcDatatypeDescriptor {
+                base: NcDescriptor {
+                    description: Some("Method result error".to_string()),
+                },
+                name: "NcMethodResultError".to_string(),
+                type_: NcDatatypeType::Struct,
+                constraints: None,
+            },
+            fields: vec![NcFieldDescriptor {
+                base: NcDescriptor { description: None },
+                name: "errorMessage".to_string(),
+                type_name: Some("NcString".to_string()),
+                is_nullable: false,
+                is_sequence: false,
+                constraints: None,
+            }],
+            parent_type: Some("NcMethodResult".to_string()),
+        };
+        if include_inherited {
+            let base = NcMethodResult::get_type_descriptor(true);
+            current.fields.extend(base.fields);
+        }
+        current
+    }
 }
 
 #[derive(Serialize, Debug)]
 #[serde(untagged)]
 pub enum ResponsePayload {
-    Result(ResponseResult),
-    Error(ResponseError),
+    Result(NcMethodResultPropertyValue),
+    Error(NcMethodResultError),
 }
 
 #[derive(Serialize, Debug)]
@@ -322,85 +2246,53 @@ impl From<u32> for NcPropertyChangeType {
     }
 }
 
-#[derive(Serialize, Debug, Clone)]
-pub struct PropertyChangedEventData {
-    #[serde(rename = "propertyId")]
-    pub property_id: ElementId,
-    #[serde(rename = "changeType")]
-    pub change_type: NcPropertyChangeType,
-    pub value: Value,
-    #[serde(rename = "sequenceItemIndex")]
-    pub sequence_item_index: Option<u64>,
-}
-
-#[derive(Serialize, Debug, Clone)]
-pub struct PropertyChangedEvent {
-    pub oid: u64,
-    #[serde(rename = "eventId")]
-    pub event_id_: ElementId,
-    #[serde(rename = "eventData")]
-    pub event_data: PropertyChangedEventData,
-}
-
-impl PropertyChangedEvent {
-    pub fn new(oid: u64, event_data: PropertyChangedEventData) -> Self {
-        PropertyChangedEvent {
-            oid,
-            event_id_: ElementId { level: 1, index: 1 },
-            event_data,
-        }
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct NcTouchpointResourceNmos {
-    #[serde(rename = "resourceType")]
-    pub resource_type: String,
-    pub id: String,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct NcTouchpointResourceNmosChannelMapping {
-    #[serde(rename = "resourceType")]
-    pub resource_type: String,
-    pub id: String,
-    #[serde(rename = "ioId")]
-    pub io_id: String,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct NcTouchpointBase {
-    #[serde(rename = "contextNamespace")]
-    pub context_namespace: String,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct NcTouchpointNmos {
-    #[serde(flatten)]
-    pub base: NcTouchpointBase,
-    pub resource: NcTouchpointResourceNmos,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct NcTouchpointNmosChannelMapping {
-    #[serde(flatten)]
-    pub base: NcTouchpointBase,
-    pub resource: NcTouchpointResourceNmosChannelMapping,
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
-pub enum NcTouchpoint {
-    Nmos(NcTouchpointNmos),
-    NmosChannelMapping(NcTouchpointNmosChannelMapping),
+pub enum NcPropertyConstraints {
+    Number(NcPropertyConstraintsNumber),
+    String(NcPropertyConstraintsString),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NcPropertyConstraintsBase {
     #[serde(rename = "propertyId")]
-    pub property_id: ElementId,
+    pub property_id: NcElementId,
     #[serde(rename = "defaultValue")]
     pub default_value: Option<Value>,
+}
+
+impl NcPropertyConstraintsBase {
+    pub fn get_type_descriptor(_include_inherited: bool) -> NcDatatypeDescriptorStruct {
+        NcDatatypeDescriptorStruct {
+            base: NcDatatypeDescriptor {
+                base: NcDescriptor {
+                    description: Some("Base property constraints".to_string()),
+                },
+                name: "NcPropertyConstraints".to_string(),
+                type_: NcDatatypeType::Struct,
+                constraints: None,
+            },
+            fields: vec![
+                NcFieldDescriptor {
+                    base: NcDescriptor { description: None },
+                    name: "propertyId".to_string(),
+                    type_name: Some("NcPropertyId".to_string()),
+                    is_nullable: false,
+                    is_sequence: false,
+                    constraints: None,
+                },
+                NcFieldDescriptor {
+                    base: NcDescriptor { description: None },
+                    name: "defaultValue".to_string(),
+                    type_name: None,
+                    is_nullable: true,
+                    is_sequence: false,
+                    constraints: None,
+                },
+            ],
+            parent_type: None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -412,6 +2304,53 @@ pub struct NcPropertyConstraintsNumber {
     pub step: Option<f64>,
 }
 
+impl NcPropertyConstraintsNumber {
+    pub fn get_type_descriptor(include_inherited: bool) -> NcDatatypeDescriptorStruct {
+        let mut current = NcDatatypeDescriptorStruct {
+            base: NcDatatypeDescriptor {
+                base: NcDescriptor {
+                    description: Some("Numeric property constraints".to_string()),
+                },
+                name: "NcPropertyConstraintsNumber".to_string(),
+                type_: NcDatatypeType::Struct,
+                constraints: None,
+            },
+            fields: vec![
+                NcFieldDescriptor {
+                    base: NcDescriptor { description: None },
+                    name: "maximum".to_string(),
+                    type_name: None,
+                    is_nullable: true,
+                    is_sequence: false,
+                    constraints: None,
+                },
+                NcFieldDescriptor {
+                    base: NcDescriptor { description: None },
+                    name: "minimum".to_string(),
+                    type_name: None,
+                    is_nullable: true,
+                    is_sequence: false,
+                    constraints: None,
+                },
+                NcFieldDescriptor {
+                    base: NcDescriptor { description: None },
+                    name: "step".to_string(),
+                    type_name: None,
+                    is_nullable: true,
+                    is_sequence: false,
+                    constraints: None,
+                },
+            ],
+            parent_type: Some("NcPropertyConstraints".to_string()),
+        };
+        if include_inherited {
+            let base = NcPropertyConstraintsBase::get_type_descriptor(true);
+            current.fields.extend(base.fields);
+        }
+        current
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NcPropertyConstraintsString {
     #[serde(flatten)]
@@ -421,11 +2360,43 @@ pub struct NcPropertyConstraintsString {
     pub pattern: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum NcPropertyConstraints {
-    Number(NcPropertyConstraintsNumber),
-    String(NcPropertyConstraintsString),
+impl NcPropertyConstraintsString {
+    pub fn get_type_descriptor(include_inherited: bool) -> NcDatatypeDescriptorStruct {
+        let mut current = NcDatatypeDescriptorStruct {
+            base: NcDatatypeDescriptor {
+                base: NcDescriptor {
+                    description: Some("String property constraints".to_string()),
+                },
+                name: "NcPropertyConstraintsString".to_string(),
+                type_: NcDatatypeType::Struct,
+                constraints: None,
+            },
+            fields: vec![
+                NcFieldDescriptor {
+                    base: NcDescriptor { description: None },
+                    name: "maxCharacters".to_string(),
+                    type_name: Some("NcUint32".to_string()),
+                    is_nullable: true,
+                    is_sequence: false,
+                    constraints: None,
+                },
+                NcFieldDescriptor {
+                    base: NcDescriptor { description: None },
+                    name: "pattern".to_string(),
+                    type_name: Some("NcRegex".to_string()),
+                    is_nullable: true,
+                    is_sequence: false,
+                    constraints: None,
+                },
+            ],
+            parent_type: Some("NcPropertyConstraints".to_string()),
+        };
+        if include_inherited {
+            let base = NcPropertyConstraintsBase::get_type_descriptor(true);
+            current.fields.extend(base.fields);
+        }
+        current
+    }
 }
 
 #[derive(Serialize, Debug)]
@@ -433,39 +2404,6 @@ pub struct WsNotificationMessage {
     pub notifications: Vec<PropertyChangedEvent>,
     #[serde(rename = "messageType")]
     pub message_type: u16,
-}
-
-#[derive(Serialize, Debug)]
-pub struct NcBlockMemberDescriptor {
-    pub role: String,
-    pub oid: u64,
-    #[serde(rename = "constantOid")]
-    pub constant_oid: bool,
-    #[serde(rename = "classId")]
-    pub class_id: Vec<u32>,
-    #[serde(rename = "userLabel")]
-    pub user_label: String,
-    pub owner: u64,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct NcManufacturer {
-    pub name: String,
-    #[serde(rename = "organizationId")]
-    pub organization_id: Option<i32>,
-    pub website: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct NcProduct {
-    pub name: String,
-    pub key: String,
-    #[serde(rename = "revisionLevel")]
-    pub revision_level: String,
-    #[serde(rename = "brandName")]
-    pub brand_name: Option<String>,
-    pub uuid: Option<String>,
-    pub description: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -498,13 +2436,6 @@ impl From<u32> for NcDeviceGenericState {
             _ => NcDeviceGenericState::Unknown,
         }
     }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct NcDeviceOperationalState {
-    pub generic: NcDeviceGenericState,
-    #[serde(rename = "deviceSpecificDetails")]
-    pub device_specific_details: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/nc_block.rs
+++ b/src/nc_block.rs
@@ -1,6 +1,7 @@
 use crate::data_types::{
-    ElementId, IdArgs, IdArgsValue, NcBlockMemberDescriptor, NcMethodStatus, NcPropertyChangeType,
-    PropertyChangedEvent, PropertyChangedEventData,
+    IdArgs, IdArgsValue, NcBlockMemberDescriptor, NcClassDescriptor, NcElementId,
+    NcMethodDescriptor, NcMethodStatus, NcParameterDescriptor, NcPropertyChangeType,
+    NcPropertyDescriptor, PropertyChangedEvent, PropertyChangedEventData,
 };
 use crate::nc_object::{NcMember, NcObject};
 use itertools::Itertools;
@@ -79,7 +80,7 @@ impl NcMember for NcBlock {
             match id_args_value.id.level {
                 2 => (
                     Some("Could not find the property".to_string()),
-                    NcMethodStatus::BadOid,
+                    NcMethodStatus::PropertyNotImplemented,
                 ),
                 _ => self.base.set_property(oid, id_args_value),
             }
@@ -93,7 +94,7 @@ impl NcMember for NcBlock {
     fn invoke_method(
         &self,
         oid: u64,
-        method_id: ElementId,
+        method_id: NcElementId,
         args: Value,
     ) -> (Option<String>, Option<Value>, NcMethodStatus) {
         if oid == self.base.oid {
@@ -129,6 +130,157 @@ impl NcMember for NcBlock {
                 NcMethodStatus::BadOid,
             )
         }
+    }
+}
+
+impl NcBlock {
+    pub fn get_class_descriptor(include_inherited: bool) -> NcClassDescriptor {
+        let mut descriptor = NcClassDescriptor {
+            base: crate::data_types::NcDescriptor { description: Some("NcBlock class descriptor".to_string()) },
+            class_id: vec![1, 1],
+            name: "NcBlock".to_string(),
+            fixed_role: None,
+            properties: vec![
+                NcPropertyDescriptor {
+                    base: crate::data_types::NcDescriptor { description: Some("TRUE if block is functional".to_string()) },
+                    id: NcElementId { level: 2, index: 1 },
+                    name: "enabled".to_string(),
+                    type_name: Some("NcBoolean".to_string()),
+                    is_read_only: true,
+                    is_nullable: false,
+                    is_sequence: false,
+                    is_deprecated: false,
+                    constraints: None,
+                },
+                NcPropertyDescriptor {
+                    base: crate::data_types::NcDescriptor { description: Some("Descriptors of this block's members".to_string()) },
+                    id: NcElementId { level: 2, index: 2 },
+                    name: "members".to_string(),
+                    type_name: Some("NcBlockMemberDescriptor".to_string()),
+                    is_read_only: true,
+                    is_nullable: false,
+                    is_sequence: true,
+                    is_deprecated: false,
+                    constraints: None,
+                },
+            ],
+            methods: vec![
+                NcMethodDescriptor {
+                    base: crate::data_types::NcDescriptor { description: Some("Gets descriptors of members of the block".to_string()) },
+                    id: NcElementId { level: 2, index: 1 },
+                    name: "GetMemberDescriptors".to_string(),
+                    result_datatype: "NcMethodResultBlockMemberDescriptors".to_string(),
+                    parameters: vec![NcParameterDescriptor {
+                        base: crate::data_types::NcDescriptor { description: Some("If recurse is set to true, nested members can be retrieved".to_string()) },
+                        name: "recurse".to_string(),
+                        type_name: Some("NcBoolean".to_string()),
+                        is_nullable: false,
+                        is_sequence: false,
+                        constraints: None,
+                    }],
+                    is_deprecated: false,
+                },
+                NcMethodDescriptor {
+                    base: crate::data_types::NcDescriptor { description: Some("Finds member(s) by path".to_string()) },
+                    id: NcElementId { level: 2, index: 2 },
+                    name: "FindMembersByPath".to_string(),
+                    result_datatype: "NcMethodResultBlockMemberDescriptors".to_string(),
+                    parameters: vec![NcParameterDescriptor {
+                        base: crate::data_types::NcDescriptor { description: Some("Relative path to search for (MUST not include the role of the block targeted by oid)".to_string()) },
+                        name: "path".to_string(),
+                        type_name: Some("NcRolePath".to_string()),
+                        is_nullable: false,
+                        is_sequence: false,
+                        constraints: None,
+                    }],
+                    is_deprecated: false,
+                },
+                NcMethodDescriptor {
+                    base: crate::data_types::NcDescriptor { description: Some("Finds members with given role name or fragment".to_string()) },
+                    id: NcElementId { level: 2, index: 3 },
+                    name: "FindMembersByRole".to_string(),
+                    result_datatype: "NcMethodResultBlockMemberDescriptors".to_string(),
+                    parameters: vec![
+                        NcParameterDescriptor {
+                            base: crate::data_types::NcDescriptor { description: Some("Role text to search for".to_string()) },
+                            name: "role".to_string(),
+                            type_name: Some("NcString".to_string()),
+                            is_nullable: false,
+                            is_sequence: false,
+                            constraints: None,
+                        },
+                        NcParameterDescriptor {
+                            base: crate::data_types::NcDescriptor { description: Some("Signals if the comparison should be case sensitive".to_string()) },
+                            name: "caseSensitive".to_string(),
+                            type_name: Some("NcBoolean".to_string()),
+                            is_nullable: false,
+                            is_sequence: false,
+                            constraints: None,
+                        },
+                        NcParameterDescriptor {
+                            base: crate::data_types::NcDescriptor { description: Some("TRUE to only return exact matches".to_string()) },
+                            name: "matchWholeString".to_string(),
+                            type_name: Some("NcBoolean".to_string()),
+                            is_nullable: false,
+                            is_sequence: false,
+                            constraints: None,
+                        },
+                        NcParameterDescriptor {
+                            base: crate::data_types::NcDescriptor { description: Some("TRUE to search nested blocks".to_string()) },
+                            name: "recurse".to_string(),
+                            type_name: Some("NcBoolean".to_string()),
+                            is_nullable: false,
+                            is_sequence: false,
+                            constraints: None,
+                        },
+                    ],
+                    is_deprecated: false,
+                },
+                NcMethodDescriptor {
+                    base: crate::data_types::NcDescriptor { description: Some("Finds members with given class id".to_string()) },
+                    id: NcElementId { level: 2, index: 4 },
+                    name: "FindMembersByClassId".to_string(),
+                    result_datatype: "NcMethodResultBlockMemberDescriptors".to_string(),
+                    parameters: vec![
+                        NcParameterDescriptor {
+                            base: crate::data_types::NcDescriptor { description: Some("Class id to search for".to_string()) },
+                            name: "classId".to_string(),
+                            type_name: Some("NcClassId".to_string()),
+                            is_nullable: false,
+                            is_sequence: false,
+                            constraints: None,
+                        },
+                        NcParameterDescriptor {
+                            base: crate::data_types::NcDescriptor { description: Some("If TRUE it will also include derived class descriptors".to_string()) },
+                            name: "includeDerived".to_string(),
+                            type_name: Some("NcBoolean".to_string()),
+                            is_nullable: false,
+                            is_sequence: false,
+                            constraints: None,
+                        },
+                        NcParameterDescriptor {
+                            base: crate::data_types::NcDescriptor { description: Some("TRUE to search nested blocks".to_string()) },
+                            name: "recurse".to_string(),
+                            type_name: Some("NcBoolean".to_string()),
+                            is_nullable: false,
+                            is_sequence: false,
+                            constraints: None,
+                        },
+                    ],
+                    is_deprecated: false,
+                },
+            ],
+            events: vec![],
+        };
+
+        if include_inherited {
+            let base_desc = crate::nc_object::NcObject::get_class_descriptor(true);
+            descriptor.properties.extend(base_desc.properties);
+            descriptor.methods.extend(base_desc.methods);
+            descriptor.events.extend(base_desc.events);
+        }
+
+        descriptor
     }
 }
 
@@ -173,7 +325,7 @@ impl NcBlock {
         let _ = self.base.notifier.send(PropertyChangedEvent::new(
             self.base.oid,
             PropertyChangedEventData {
-                property_id: ElementId { level: 2, index: 2 },
+                property_id: NcElementId { level: 2, index: 2 },
                 change_type: NcPropertyChangeType::ValueChanged,
                 value: json!(members_descriptors),
                 sequence_item_index: None,
@@ -215,6 +367,7 @@ impl NcBlock {
         self.members
             .iter()
             .map(|m| NcBlockMemberDescriptor {
+                base: crate::data_types::NcDescriptor { description: None },
                 role: m.get_role().to_owned(),
                 oid: m.get_oid(),
                 constant_oid: m.get_constant_oid(),
@@ -227,6 +380,7 @@ impl NcBlock {
 
     pub fn make_member_descriptor(m: &dyn NcMember, owner: u64) -> NcBlockMemberDescriptor {
         NcBlockMemberDescriptor {
+            base: crate::data_types::NcDescriptor { description: None },
             role: m.get_role().to_owned(),
             oid: m.get_oid(),
             constant_oid: m.get_constant_oid(),
@@ -418,17 +572,6 @@ impl NcBlock {
                     results.extend(block.find_members_by_class_id(args.clone()));
                 }
             }
-        }
-
-        if self.is_root && matches_class_id(&self.base.class_id) {
-            results.push(NcBlockMemberDescriptor {
-                role: self.base.role.clone(),
-                oid: self.base.oid,
-                constant_oid: self.base.constant_oid,
-                class_id: self.base.class_id.clone(),
-                user_label: self.base.user_label.clone().unwrap_or_default(),
-                owner: self.base.oid,
-            });
         }
 
         results

--- a/src/nc_class_manager.rs
+++ b/src/nc_class_manager.rs
@@ -1,0 +1,731 @@
+use crate::data_types::{
+    IdArgs, IdArgsValue, NcAnyDatatypeDescriptor, NcClassDescriptor, NcDatatypeDescriptor,
+    NcDatatypeDescriptorStruct as DtStruct, NcDatatypeDescriptorTypeDef as DtTypeDef,
+    NcDatatypeType, NcElementId, NcMethodStatus, NcParameterDescriptor, NcPropertyConstraints,
+    NcPropertyDescriptor, NcTouchpoint, PropertyChangedEvent,
+};
+use crate::nc_manager::NcManager;
+use crate::nc_object::NcMember;
+use serde_json::{Value, json};
+use std::any::Any;
+use std::collections::HashMap;
+use tokio::sync::mpsc;
+
+pub struct NcClassManager {
+    pub base: NcManager,
+    control_classes_register: HashMap<String, NcClassDescriptor>,
+    data_types_register: HashMap<String, NcAnyDatatypeDescriptor>,
+}
+
+impl NcMember for NcClassManager {
+    fn member_type(&self) -> &'static str {
+        "NcClassManager"
+    }
+    fn get_role(&self) -> &str {
+        self.base.get_role()
+    }
+    fn get_oid(&self) -> u64 {
+        self.base.get_oid()
+    }
+    fn get_constant_oid(&self) -> bool {
+        self.base.get_constant_oid()
+    }
+    fn get_class_id(&self) -> &[u32] {
+        self.base.get_class_id()
+    }
+    fn get_user_label(&self) -> Option<&str> {
+        self.base.get_user_label()
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+
+    fn get_property(&self, _oid: u64, id_args: &IdArgs) -> (Option<String>, Value, NcMethodStatus) {
+        match (id_args.id.level, id_args.id.index) {
+            (3, 1) => {
+                let list: Vec<NcClassDescriptor> =
+                    self.control_classes_register.values().cloned().collect();
+                (None, json!(list), NcMethodStatus::Ok)
+            }
+            (3, 2) => {
+                let list: Vec<NcAnyDatatypeDescriptor> =
+                    self.data_types_register.values().cloned().collect();
+                (None, json!(list), NcMethodStatus::Ok)
+            }
+            _ => self.base.get_property(_oid, id_args),
+        }
+    }
+
+    fn set_property(
+        &mut self,
+        _oid: u64,
+        id_args_value: IdArgsValue,
+    ) -> (Option<String>, NcMethodStatus) {
+        if id_args_value.id.level == 3 {
+            match id_args_value.id.index {
+                1 | 2 => (
+                    Some("Property is readonly".to_string()),
+                    NcMethodStatus::Readonly,
+                ),
+                _ => (
+                    Some("Could not find the property or it is read-only".to_string()),
+                    NcMethodStatus::PropertyNotImplemented,
+                ),
+            }
+        } else {
+            self.base.set_property(_oid, id_args_value)
+        }
+    }
+
+    fn invoke_method(
+        &self,
+        oid: u64,
+        method_id: NcElementId,
+        args: Value,
+    ) -> (Option<String>, Option<Value>, NcMethodStatus) {
+        if oid == self.base.get_oid() {
+            match (method_id.level, method_id.index) {
+                (3, 1) => {
+                    let class_id = args.get("classId").and_then(|v| v.as_array()).map(|arr| {
+                        arr.iter()
+                            .filter_map(|n| n.as_u64().map(|x| x as u32))
+                            .collect::<Vec<u32>>()
+                    });
+                    if class_id.is_none() {
+                        return (
+                            Some("No class identity has been provided".to_string()),
+                            None,
+                            NcMethodStatus::InvalidRequest,
+                        );
+                    }
+                    let include_inherited = args.get("includeInherited").and_then(|v| v.as_bool());
+                    if include_inherited.is_none() {
+                        return (
+                            Some("No includeInherited argument provided".to_string()),
+                            None,
+                            NcMethodStatus::InvalidRequest,
+                        );
+                    }
+
+                    let class_id = class_id.unwrap();
+                    let include_inherited = include_inherited.unwrap();
+                    match self.get_control_class_descriptor(&class_id, include_inherited) {
+                        Some(desc) => (None, Some(json!(desc)), NcMethodStatus::Ok),
+                        None => (
+                            Some("Descriptor for class could not be found".to_string()),
+                            None,
+                            NcMethodStatus::InvalidRequest,
+                        ),
+                    }
+                }
+                (3, 2) => {
+                    let name = args
+                        .get("name")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string());
+                    if name.is_none() {
+                        return (
+                            Some("No name argument has been provided".to_string()),
+                            None,
+                            NcMethodStatus::InvalidRequest,
+                        );
+                    }
+                    let include_inherited = args.get("includeInherited").and_then(|v| v.as_bool());
+                    if include_inherited.is_none() {
+                        return (
+                            Some("No includeInherited argument provided".to_string()),
+                            None,
+                            NcMethodStatus::InvalidRequest,
+                        );
+                    }
+
+                    let name = name.unwrap();
+                    let include_inherited = include_inherited.unwrap();
+                    match self.get_datatype_descriptor(&name, include_inherited) {
+                        Some(desc) => (None, Some(json!(desc)), NcMethodStatus::Ok),
+                        None => (
+                            Some("Descriptor for type could not be found".to_string()),
+                            None,
+                            NcMethodStatus::InvalidRequest,
+                        ),
+                    }
+                }
+                _ => self.base.invoke_method(oid, method_id, args),
+            }
+        } else {
+            self.base.invoke_method(oid, method_id, args)
+        }
+    }
+}
+
+impl NcClassManager {
+    fn class_id_to_key(id: &[u32]) -> String {
+        id.iter()
+            .map(|n| n.to_string())
+            .collect::<Vec<_>>()
+            .join(".")
+    }
+
+    fn generate_class_descriptors() -> HashMap<String, NcClassDescriptor> {
+        let mut reg: HashMap<String, NcClassDescriptor> = HashMap::new();
+
+        let classes = vec![
+            crate::nc_object::NcObject::get_class_descriptor(false),
+            crate::nc_block::NcBlock::get_class_descriptor(false),
+            crate::nc_manager::NcManager::get_class_descriptor(false),
+            crate::nc_device_manager::NcDeviceManager::get_class_descriptor(false),
+            crate::nc_class_manager::NcClassManager::get_class_descriptor(false),
+        ];
+
+        for desc in classes {
+            let key = NcClassManager::class_id_to_key(&desc.class_id);
+            reg.insert(key, desc);
+        }
+
+        reg
+    }
+
+    pub fn get_datatype_descriptor(
+        &self,
+        name: &str,
+        include_inherited: bool,
+    ) -> Option<NcAnyDatatypeDescriptor> {
+        if !include_inherited {
+            return self.data_types_register.get(name).cloned();
+        }
+
+        // For include_inherited = true, rebuild known struct descriptors using their static builders
+
+        let rebuilt: Option<DtStruct> = match name {
+            "NcFieldDescriptor" => Some(crate::data_types::NcFieldDescriptor::get_type_descriptor(
+                true,
+            )),
+            "NcEnumItemDescriptor" => {
+                Some(crate::data_types::NcEnumItemDescriptor::get_type_descriptor(true))
+            }
+            "NcPropertyDescriptor" => {
+                Some(crate::data_types::NcPropertyDescriptor::get_type_descriptor(true))
+            }
+            "NcMethodDescriptor" => Some(
+                crate::data_types::NcMethodDescriptor::get_type_descriptor(true),
+            ),
+            "NcEventDescriptor" => Some(crate::data_types::NcEventDescriptor::get_type_descriptor(
+                true,
+            )),
+            "NcParameterDescriptor" => {
+                Some(crate::data_types::NcParameterDescriptor::get_type_descriptor(true))
+            }
+            "NcClassDescriptor" => Some(crate::data_types::NcClassDescriptor::get_type_descriptor(
+                true,
+            )),
+            "NcDescriptor" => Some(crate::data_types::NcDescriptor::get_type_descriptor(true)),
+            "NcDatatypeDescriptor" => {
+                Some(crate::data_types::NcDatatypeDescriptor::get_type_descriptor(true))
+            }
+            "NcDatatypeDescriptorPrimitive" => {
+                Some(crate::data_types::NcDatatypeDescriptorPrimitive::get_type_descriptor(true))
+            }
+            "NcDatatypeDescriptorEnum" => {
+                Some(crate::data_types::NcDatatypeDescriptorEnum::get_type_descriptor(true))
+            }
+            "NcDatatypeDescriptorTypeDef" => {
+                Some(crate::data_types::NcDatatypeDescriptorTypeDef::get_type_descriptor(true))
+            }
+            "NcDatatypeDescriptorStruct" => {
+                Some(crate::data_types::NcDatatypeDescriptorStruct::get_type_descriptor(true))
+            }
+            "NcParameterConstraints" => {
+                Some(crate::data_types::NcParameterConstraints::get_type_descriptor(true))
+            }
+            "NcParameterConstraintsNumber" => {
+                Some(crate::data_types::NcParameterConstraintsNumber::get_type_descriptor(true))
+            }
+            "NcParameterConstraintsString" => {
+                Some(crate::data_types::NcParameterConstraintsString::get_type_descriptor(true))
+            }
+            "NcPropertyConstraints" => {
+                Some(crate::data_types::NcPropertyConstraintsBase::get_type_descriptor(true))
+            }
+            "NcPropertyConstraintsNumber" => {
+                Some(crate::data_types::NcPropertyConstraintsNumber::get_type_descriptor(true))
+            }
+            "NcPropertyConstraintsString" => {
+                Some(crate::data_types::NcPropertyConstraintsString::get_type_descriptor(true))
+            }
+            "NcElementId" => Some(crate::data_types::NcElementId::get_type_descriptor(true)),
+            "NcPropertyId" => Some(crate::data_types::NcPropertyId::get_type_descriptor(true)),
+            "NcMethodId" => Some(crate::data_types::NcMethodId::get_type_descriptor(true)),
+            "NcEventId" => Some(crate::data_types::NcEventId::get_type_descriptor(true)),
+            "NcManufacturer" => Some(crate::data_types::NcManufacturer::get_type_descriptor(true)),
+            "NcProduct" => Some(crate::data_types::NcProduct::get_type_descriptor(true)),
+            "NcDeviceOperationalState" => {
+                Some(crate::data_types::NcDeviceOperationalState::get_type_descriptor(true))
+            }
+            "PropertyChangedEventData" | "NcPropertyChangedEventData" => {
+                Some(crate::data_types::PropertyChangedEventData::get_type_descriptor(true))
+            }
+            "NcBlockMemberDescriptor" => {
+                Some(crate::data_types::NcBlockMemberDescriptor::get_type_descriptor(true))
+            }
+            "NcTouchpoint" => Some(crate::data_types::NcTouchpointBase::get_type_descriptor(
+                true,
+            )),
+            "NcTouchpointNmos" => Some(crate::data_types::NcTouchpointNmos::get_type_descriptor(
+                true,
+            )),
+            "NcTouchpointNmosChannelMapping" => {
+                Some(crate::data_types::NcTouchpointNmosChannelMapping::get_type_descriptor(true))
+            }
+            "NcTouchpointResource" => {
+                Some(crate::data_types::NcTouchpointResourceBase::get_type_descriptor(true))
+            }
+            "NcTouchpointResourceNmos" => {
+                Some(crate::data_types::NcTouchpointResourceNmos::get_type_descriptor(true))
+            }
+            "NcTouchpointResourceNmosChannelMapping" => Some(
+                crate::data_types::NcTouchpointResourceNmosChannelMapping::get_type_descriptor(
+                    true,
+                ),
+            ),
+            "NcMethodResult" => Some(crate::data_types::NcMethodResult::get_type_descriptor(true)),
+            "NcMethodResultPropertyValue" => {
+                Some(crate::data_types::NcMethodResultPropertyValue::get_type_descriptor(true))
+            }
+            "NcMethodResultError" => Some(
+                crate::data_types::NcMethodResultError::get_type_descriptor(true),
+            ),
+            "NcMethodResultBlockMemberDescriptors" => Some(
+                crate::data_types::NcMethodResultBlockMemberDescriptors::get_type_descriptor(true),
+            ),
+            "NcMethodResultClassDescriptor" => {
+                Some(crate::data_types::NcMethodResultClassDescriptor::get_type_descriptor(true))
+            }
+            "NcMethodResultDatatypeDescriptor" => {
+                Some(crate::data_types::NcMethodResultDatatypeDescriptor::get_type_descriptor(true))
+            }
+            "NcMethodResultId" => Some(crate::data_types::NcMethodResultId::get_type_descriptor(
+                true,
+            )),
+            "NcMethodResultLength" => {
+                Some(crate::data_types::NcMethodResultLength::get_type_descriptor(true))
+            }
+
+            // Types registered directly or non-structs: fall back to registry
+            _ => None,
+        };
+
+        if let Some(dt) = rebuilt {
+            return Some(NcAnyDatatypeDescriptor::Struct(dt));
+        }
+
+        // For primitives, typedefs, enums, or unknowns, return the cached version
+        self.data_types_register.get(name).cloned()
+    }
+
+    fn generate_type_descriptors() -> HashMap<String, NcAnyDatatypeDescriptor> {
+        let mut reg: HashMap<String, NcAnyDatatypeDescriptor> = HashMap::new();
+
+        let mut add_prim = |name: &str, description: &str| {
+            reg.insert(
+                name.to_string(),
+                NcAnyDatatypeDescriptor::Primitive(NcDatatypeDescriptor {
+                    base: crate::data_types::NcDescriptor {
+                        description: Some(description.to_string()),
+                    },
+                    name: name.to_string(),
+                    type_: NcDatatypeType::Primitive,
+                    constraints: None,
+                }),
+            );
+        };
+
+        add_prim("NcBoolean", "Boolean primitive");
+        add_prim("NcInt16", "Signed 16-bit integer");
+        add_prim("NcInt32", "Signed 32-bit integer");
+        add_prim("NcInt64", "Signed 64-bit integer");
+        add_prim("NcUint16", "Unsigned 16-bit integer");
+        add_prim("NcUint32", "Unsigned 32-bit integer");
+        add_prim("NcUint64", "Unsigned 64-bit integer");
+        add_prim("NcFloat32", "32-bit floating point");
+        add_prim("NcFloat64", "64-bit floating point");
+        add_prim("NcString", "String primitive");
+
+        let mut add_struct = |dt: DtStruct| {
+            let name = dt.base.name.clone();
+            reg.insert(name, NcAnyDatatypeDescriptor::Struct(dt));
+        };
+        add_struct(crate::data_types::NcElementId::get_type_descriptor(false));
+        add_struct(crate::data_types::NcEventId::get_type_descriptor(false));
+        add_struct(crate::data_types::NcMethodId::get_type_descriptor(false));
+        add_struct(crate::data_types::NcPropertyId::get_type_descriptor(false));
+        add_struct(crate::data_types::NcManufacturer::get_type_descriptor(
+            false,
+        ));
+        add_struct(crate::data_types::NcProduct::get_type_descriptor(false));
+        add_struct(crate::data_types::NcDeviceOperationalState::get_type_descriptor(false));
+        add_struct(crate::data_types::PropertyChangedEventData::get_type_descriptor(false));
+        add_struct(crate::data_types::NcBlockMemberDescriptor::get_type_descriptor(false));
+        add_struct(crate::data_types::NcDatatypeDescriptor::get_type_descriptor(false));
+        add_struct(crate::data_types::NcDatatypeDescriptorPrimitive::get_type_descriptor(false));
+        add_struct(crate::data_types::NcDatatypeDescriptorEnum::get_type_descriptor(false));
+        add_struct(crate::data_types::NcDatatypeDescriptorTypeDef::get_type_descriptor(false));
+        add_struct(crate::data_types::NcDatatypeDescriptorStruct::get_type_descriptor(false));
+        add_struct(crate::data_types::NcFieldDescriptor::get_type_descriptor(
+            false,
+        ));
+        add_struct(crate::data_types::NcEnumItemDescriptor::get_type_descriptor(false));
+        add_struct(crate::data_types::NcDescriptor::get_type_descriptor(false));
+        add_struct(crate::data_types::NcPropertyDescriptor::get_type_descriptor(false));
+        add_struct(crate::data_types::NcMethodDescriptor::get_type_descriptor(
+            false,
+        ));
+        add_struct(crate::data_types::NcEventDescriptor::get_type_descriptor(
+            false,
+        ));
+        add_struct(crate::data_types::NcParameterDescriptor::get_type_descriptor(false));
+        add_struct(crate::data_types::NcClassDescriptor::get_type_descriptor(
+            false,
+        ));
+        add_struct(crate::data_types::NcDescriptor::get_type_descriptor(false));
+        add_struct(crate::data_types::NcTouchpointBase::get_type_descriptor(
+            false,
+        ));
+        add_struct(crate::data_types::NcTouchpointNmos::get_type_descriptor(
+            false,
+        ));
+        add_struct(crate::data_types::NcTouchpointNmosChannelMapping::get_type_descriptor(false));
+        add_struct(crate::data_types::NcTouchpointResourceBase::get_type_descriptor(false));
+        add_struct(crate::data_types::NcTouchpointResourceNmos::get_type_descriptor(false));
+        add_struct(
+            crate::data_types::NcTouchpointResourceNmosChannelMapping::get_type_descriptor(false),
+        );
+        add_struct(crate::data_types::NcParameterConstraints::get_type_descriptor(false));
+        add_struct(crate::data_types::NcParameterConstraintsNumber::get_type_descriptor(false));
+        add_struct(crate::data_types::NcParameterConstraintsString::get_type_descriptor(false));
+        add_struct(crate::data_types::NcPropertyConstraintsBase::get_type_descriptor(false));
+        add_struct(crate::data_types::NcPropertyConstraintsNumber::get_type_descriptor(false));
+        add_struct(crate::data_types::NcPropertyConstraintsString::get_type_descriptor(false));
+        add_struct(crate::data_types::NcMethodResult::get_type_descriptor(
+            false,
+        ));
+        add_struct(crate::data_types::NcMethodResultPropertyValue::get_type_descriptor(false));
+        add_struct(crate::data_types::NcMethodResultError::get_type_descriptor(
+            false,
+        ));
+        add_struct(
+            crate::data_types::NcMethodResultBlockMemberDescriptors::get_type_descriptor(false),
+        );
+        add_struct(crate::data_types::NcMethodResultClassDescriptor::get_type_descriptor(false));
+        add_struct(crate::data_types::NcMethodResultDatatypeDescriptor::get_type_descriptor(false));
+        add_struct(crate::data_types::NcMethodResultId::get_type_descriptor(
+            false,
+        ));
+        add_struct(crate::data_types::NcMethodResultLength::get_type_descriptor(false));
+
+        let mut add_enum = |name: &str, items: Vec<(&str, u16, &str)>, description: &str| {
+            let enum_desc = crate::data_types::NcDatatypeDescriptorEnum {
+                base: NcDatatypeDescriptor {
+                    base: crate::data_types::NcDescriptor {
+                        description: Some(description.to_string()),
+                    },
+                    name: name.to_string(),
+                    type_: NcDatatypeType::Enum,
+                    constraints: None,
+                },
+                items: items
+                    .into_iter()
+                    .map(|(n, v, d)| crate::data_types::NcEnumItemDescriptor {
+                        base: crate::data_types::NcDescriptor {
+                            description: Some(d.to_string()),
+                        },
+                        name: n.to_string(),
+                        value: v,
+                    })
+                    .collect(),
+            };
+            reg.insert(name.to_string(), NcAnyDatatypeDescriptor::Enum(enum_desc));
+        };
+
+        add_enum(
+            "NcDeviceGenericState",
+            vec![
+                ("Unknown", 0, "Unknown"),
+                ("NormalOperation", 1, "Normal operation"),
+                ("Initializing", 2, "Initializing"),
+                ("Updating", 3, "Updating"),
+                ("LicensingError", 4, "Licensing error"),
+                ("InternalError", 5, "Internal error"),
+            ],
+            "Device generic state enumeration",
+        );
+
+        add_enum(
+            "NcPropertyChangeType",
+            vec![
+                ("ValueChanged", 0, "Value changed"),
+                ("SequenceItemAdded", 1, "Sequence item added"),
+                ("SequenceItemChanged", 2, "Sequence item changed"),
+                ("SequenceItemRemoved", 3, "Sequence item removed"),
+            ],
+            "Property change type enumeration",
+        );
+
+        add_enum(
+            "NcResetCause",
+            vec![
+                ("Unknown", 0, "Unknown"),
+                ("PowerOn", 1, "Power on"),
+                ("InternalError", 2, "Internal error"),
+                ("Upgrade", 3, "Upgrade"),
+                ("ControllerRequest", 4, "Controller request"),
+                ("ManualReset", 5, "Manual reset"),
+            ],
+            "Device reset cause enumeration",
+        );
+
+        add_enum(
+            "NcMethodStatus",
+            vec![
+                ("Ok", 200, "Ok"),
+                ("PropertyDeprecated", 298, "Property deprecated"),
+                ("MethodDeprecated", 299, "Method deprecated"),
+                ("BadCommandFormat", 400, "Bad command format"),
+                ("Unauthorized", 401, "Unauthorized"),
+                ("BadOid", 404, "Bad OID"),
+                ("Readonly", 405, "Readonly"),
+                ("InvalidRequest", 406, "Invalid request"),
+                ("Conflict", 409, "Conflict"),
+                ("BufferOverflow", 413, "Buffer overflow"),
+                ("IndexOutOfBounds", 414, "Index out of bounds"),
+                ("ParameterError", 417, "Parameter error"),
+                ("Locked", 423, "Locked"),
+                ("DeviceError", 500, "Device error"),
+                ("MethodNotImplemented", 501, "Method not implemented"),
+                ("PropertyNotImplemented", 502, "Property not implemented"),
+                ("NotReady", 503, "Not ready"),
+                ("Timeout", 504, "Timeout"),
+            ],
+            "Method status enumeration",
+        );
+
+        add_enum(
+            "NcDatatypeType",
+            vec![
+                ("Primitive", 0, "Primitive"),
+                ("Typedef", 1, "Typedef"),
+                ("Struct", 2, "Struct"),
+                ("Enum", 3, "Enum"),
+            ],
+            "Datatype kind enumeration",
+        );
+
+        let mut add_typedef = |name: &str, parent: &str, is_sequence: bool, description: &str| {
+            reg.insert(
+                name.to_string(),
+                NcAnyDatatypeDescriptor::TypeDef(DtTypeDef {
+                    base: NcDatatypeDescriptor {
+                        base: crate::data_types::NcDescriptor {
+                            description: Some(description.to_string()),
+                        },
+                        name: name.to_string(),
+                        type_: NcDatatypeType::Typedef,
+                        constraints: None,
+                    },
+                    parent_type: parent.to_string(),
+                    is_sequence,
+                }),
+            );
+        };
+
+        add_typedef(
+            "NcName",
+            "NcString",
+            false,
+            "Programmatically significant name, alphanumerics + underscore, no spaces",
+        );
+        add_typedef("NcRolePath", "NcString", true, "Role path");
+        add_typedef("NcRegex", "NcString", false, "Regex pattern");
+        add_typedef("NcRole", "NcString", false, "Role string");
+        add_typedef("NcClassId", "NcInt32", true, "Sequence of class ID fields.");
+        add_typedef("NcId", "NcUint32", false, "Identifier handler");
+        add_typedef("NcOid", "NcUint32", false, "Object id");
+        add_typedef(
+            "NcOrganizationId",
+            "NcInt32",
+            false,
+            "Unique 24-bit organization id",
+        );
+        add_typedef("NcUri", "NcString", false, "Uniform resource identifier");
+        add_typedef(
+            "NcVersionCode",
+            "NcString",
+            false,
+            "Version code in semantic versioning format",
+        );
+        add_typedef("NcUuid", "NcString", false, "UUID");
+        add_typedef(
+            "NcTimeInterval",
+            "NcInt64",
+            false,
+            "Time interval described in nanoseconds",
+        );
+
+        reg
+    }
+    pub fn get_control_class_descriptor(
+        &self,
+        class_id: &[u32],
+        include_inherited: bool,
+    ) -> Option<NcClassDescriptor> {
+        let key = NcClassManager::class_id_to_key(class_id);
+        if !include_inherited {
+            return self.control_classes_register.get(&key).cloned();
+        }
+
+        match class_id {
+            [1] => Some(crate::nc_object::NcObject::get_class_descriptor(true)),
+            [1, 1] => Some(crate::nc_block::NcBlock::get_class_descriptor(true)),
+            [1, 3] => Some(crate::nc_manager::NcManager::get_class_descriptor(true)),
+            [1, 3, 1] => {
+                Some(crate::nc_device_manager::NcDeviceManager::get_class_descriptor(true))
+            }
+            [1, 3, 2] => Some(crate::nc_class_manager::NcClassManager::get_class_descriptor(true)),
+            _ => None,
+        }
+    }
+    pub fn get_class_descriptor(include_inherited: bool) -> NcClassDescriptor {
+        let mut desc = NcClassDescriptor {
+            base: crate::data_types::NcDescriptor { description: Some("NcClassManager class descriptor".to_string()) },
+            class_id: vec![1, 3, 2],
+            name: "NcClassManager".to_string(),
+            fixed_role: Some("ClassManager".to_string()),
+            properties: vec![
+                NcPropertyDescriptor { // 3p1
+                    base: crate::data_types::NcDescriptor { description: Some("Descriptions of all control classes in the device (descriptors do not contain inherited elements)".to_string()) },
+                    id: NcElementId { level: 3, index: 1 },
+                    name: "controlClasses".to_string(),
+                    type_name: Some("NcClassDescriptor".to_string()),
+                    is_read_only: true,
+                    is_nullable: false,
+                    is_sequence: true,
+                    is_deprecated: false,
+                    constraints: None,
+                },
+                NcPropertyDescriptor { // 3p2
+                    base: crate::data_types::NcDescriptor { description: Some("Descriptions of all data types in the device (descriptors do not contain inherited elements)".to_string()) },
+                    id: NcElementId { level: 3, index: 2 },
+                    name: "datatypes".to_string(),
+                    type_name: Some("NcDatatypeDescriptor".to_string()),
+                    is_read_only: true,
+                    is_nullable: false,
+                    is_sequence: true,
+                    is_deprecated: false,
+                    constraints: None,
+                },
+            ],
+            methods: vec![
+                // 3m1 GetControlClass
+                crate::data_types::NcMethodDescriptor {
+                    base: crate::data_types::NcDescriptor { description: None },
+                    id: NcElementId { level: 3, index: 1 },
+                    name: "GetControlClass".to_string(),
+                    result_datatype: "NcMethodResultClassDescriptor".to_string(),
+                    parameters: vec![
+                        NcParameterDescriptor {
+                            base: crate::data_types::NcDescriptor { description: Some("class ID".to_string()) },
+                            name: "classId".to_string(),
+                            type_name: Some("NcClassId".to_string()),
+                            is_nullable: false,
+                            is_sequence: false,
+                            constraints: None,
+                        },
+                        NcParameterDescriptor {
+                            base: crate::data_types::NcDescriptor { description: Some("If set the descriptor would contain all inherited elements".to_string()) },
+                            name: "includeInherited".to_string(),
+                            type_name: Some("NcBoolean".to_string()),
+                            is_nullable: false,
+                            is_sequence: false,
+                            constraints: None,
+                        },
+                    ],
+                    is_deprecated: false,
+                },
+                // 3m2 GetDatatype
+                crate::data_types::NcMethodDescriptor {
+                    base: crate::data_types::NcDescriptor { description: None },
+                    id: NcElementId { level: 3, index: 2 },
+                    name: "GetDatatype".to_string(),
+                    result_datatype: "NcMethodResultDatatypeDescriptor".to_string(),
+                    parameters: vec![
+                        NcParameterDescriptor {
+                            base: crate::data_types::NcDescriptor { description: Some("name of datatype".to_string()) },
+                            name: "name".to_string(),
+                            type_name: Some("NcName".to_string()),
+                            is_nullable: false,
+                            is_sequence: false,
+                            constraints: None,
+                        },
+                        NcParameterDescriptor {
+                            base: crate::data_types::NcDescriptor { description: Some("If set the descriptor would contain all inherited elements".to_string()) },
+                            name: "includeInherited".to_string(),
+                            type_name: Some("NcBoolean".to_string()),
+                            is_nullable: false,
+                            is_sequence: false,
+                            constraints: None,
+                        },
+                    ],
+                    is_deprecated: false,
+                },
+            ],
+            events: vec![],
+        };
+
+        if include_inherited {
+            let base_desc = crate::nc_manager::NcManager::get_class_descriptor(true);
+            desc.properties.extend(base_desc.properties);
+            desc.methods.extend(base_desc.methods);
+            desc.events.extend(base_desc.events);
+        }
+
+        desc
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+impl NcClassManager {
+    pub fn new(
+        oid: u64,
+        constant_oid: bool,
+        owner: Option<u64>,
+        role: &str,
+        user_label: Option<&str>,
+        touchpoints: Option<Vec<NcTouchpoint>>,
+        runtime_property_constraints: Option<Vec<NcPropertyConstraints>>,
+        notifier: mpsc::UnboundedSender<PropertyChangedEvent>,
+    ) -> Self {
+        let base = NcManager::new(
+            vec![1, 3, 2], // Class ID for NcClassManager
+            oid,
+            constant_oid,
+            owner,
+            role,
+            user_label,
+            touchpoints,
+            runtime_property_constraints,
+            notifier,
+        );
+
+        let control_classes_register = NcClassManager::generate_class_descriptors();
+        let data_types_register = NcClassManager::generate_type_descriptors();
+
+        NcClassManager {
+            base,
+            control_classes_register,
+            data_types_register,
+        }
+    }
+}

--- a/src/nc_manager.rs
+++ b/src/nc_manager.rs
@@ -1,0 +1,119 @@
+use crate::data_types::{IdArgs, IdArgsValue, NcClassDescriptor, NcElementId, NcMethodStatus};
+use crate::nc_object::{NcMember, NcObject};
+use serde_json::Value;
+use std::any::Any;
+use tokio::sync::mpsc;
+
+#[derive(Debug, Clone)]
+pub struct NcManager {
+    pub base: NcObject,
+}
+
+impl NcManager {
+    pub fn get_class_descriptor(include_inherited: bool) -> NcClassDescriptor {
+        let mut desc = NcClassDescriptor {
+            base: crate::data_types::NcDescriptor {
+                description: Some("NcManager class descriptor".to_string()),
+            },
+            class_id: vec![1, 3],
+            name: "NcManager".to_string(),
+            fixed_role: None,
+            properties: vec![],
+            methods: vec![],
+            events: vec![],
+        };
+
+        if include_inherited {
+            let base_desc = crate::nc_object::NcObject::get_class_descriptor(true);
+            desc.properties.extend(base_desc.properties);
+            desc.methods.extend(base_desc.methods);
+            desc.events.extend(base_desc.events);
+        }
+
+        desc
+    }
+}
+
+impl NcManager {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        class_id: Vec<u32>,
+        oid: u64,
+        constant_oid: bool,
+        owner: Option<u64>,
+        role: &str,
+        user_label: Option<&str>,
+        touchpoints: Option<Vec<crate::data_types::NcTouchpoint>>,
+        runtime_property_constraints: Option<Vec<crate::data_types::NcPropertyConstraints>>,
+        notifier: mpsc::UnboundedSender<crate::data_types::PropertyChangedEvent>,
+    ) -> Self {
+        NcManager {
+            base: NcObject::new(
+                class_id,
+                oid,
+                constant_oid,
+                owner,
+                role,
+                user_label,
+                touchpoints,
+                runtime_property_constraints,
+                notifier,
+            ),
+        }
+    }
+}
+
+impl NcMember for NcManager {
+    fn member_type(&self) -> &'static str {
+        "NcManager"
+    }
+
+    fn get_role(&self) -> &str {
+        &self.base.role
+    }
+
+    fn get_oid(&self) -> u64 {
+        self.base.oid
+    }
+
+    fn get_constant_oid(&self) -> bool {
+        self.base.constant_oid
+    }
+
+    fn get_class_id(&self) -> &[u32] {
+        &self.base.class_id
+    }
+
+    fn get_user_label(&self) -> Option<&str> {
+        self.base.user_label.as_deref()
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+
+    fn get_property(&self, oid: u64, id_args: &IdArgs) -> (Option<String>, Value, NcMethodStatus) {
+        self.base.get_property(oid, id_args)
+    }
+
+    fn set_property(
+        &mut self,
+        oid: u64,
+        id_args_value: IdArgsValue,
+    ) -> (Option<String>, NcMethodStatus) {
+        self.base.set_property(oid, id_args_value)
+    }
+
+    fn invoke_method(
+        &self,
+        oid: u64,
+        method_id: NcElementId,
+        args: Value,
+    ) -> (Option<String>, Option<Value>, NcMethodStatus) {
+        self.base.invoke_method(oid, method_id, args)
+    }
+}

--- a/src/nc_object.rs
+++ b/src/nc_object.rs
@@ -1,6 +1,7 @@
 use crate::data_types::{
-    ElementId, IdArgs, IdArgsValue, NcMethodStatus, NcPropertyChangeType, NcPropertyConstraints,
-    NcTouchpoint, PropertyChangedEvent, PropertyChangedEventData,
+    IdArgs, IdArgsValue, NcClassDescriptor, NcElementId, NcEventDescriptor, NcMethodDescriptor,
+    NcMethodStatus, NcParameterDescriptor, NcPropertyChangeType, NcPropertyConstraints,
+    NcPropertyDescriptor, NcTouchpoint, PropertyChangedEvent, PropertyChangedEventData,
 };
 use serde_json::Value;
 use serde_json::json;
@@ -29,7 +30,7 @@ pub trait NcMember: Send {
     fn invoke_method(
         &self,
         _oid: u64,
-        _method_id: ElementId,
+        _method_id: NcElementId,
         _args: Value,
     ) -> (Option<String>, Option<Value>, NcMethodStatus);
 }
@@ -86,7 +87,11 @@ impl NcMember for NcObject {
                 json!(self.runtime_property_constraints),
                 NcMethodStatus::Ok,
             ),
-            _ => (None, json!(null), NcMethodStatus::BadOid),
+            _ => (
+                Some("Could not find the property".to_string()),
+                json!(null),
+                NcMethodStatus::PropertyNotImplemented,
+            ),
         }
     }
     fn set_property(
@@ -97,24 +102,39 @@ impl NcMember for NcObject {
         if id_args_value.id.level == 1 {
             match id_args_value.id.index {
                 6 => {
-                    // Set userLabel
-                    if let Some(new_label) = id_args_value.value.as_str() {
-                        self.user_label = Some(new_label.to_string());
-                        let _ = self.notifier.send(PropertyChangedEvent::new(
-                            self.oid,
-                            PropertyChangedEventData {
-                                property_id: id_args_value.id,
-                                change_type: NcPropertyChangeType::ValueChanged,
-                                value: serde_json::json!(new_label),
-                                sequence_item_index: None,
-                            },
-                        ));
-                        return (None, NcMethodStatus::Ok);
+                    // Set userLabel (accepts string or null)
+                    match &id_args_value.value {
+                        serde_json::Value::String(s) => {
+                            self.user_label = Some(s.clone());
+                            let _ = self.notifier.send(PropertyChangedEvent::new(
+                                self.oid,
+                                PropertyChangedEventData {
+                                    property_id: id_args_value.id,
+                                    change_type: NcPropertyChangeType::ValueChanged,
+                                    value: serde_json::json!(s),
+                                    sequence_item_index: None,
+                                },
+                            ));
+                            (None, NcMethodStatus::Ok)
+                        }
+                        serde_json::Value::Null => {
+                            self.user_label = None;
+                            let _ = self.notifier.send(PropertyChangedEvent::new(
+                                self.oid,
+                                PropertyChangedEventData {
+                                    property_id: id_args_value.id,
+                                    change_type: NcPropertyChangeType::ValueChanged,
+                                    value: serde_json::json!(null),
+                                    sequence_item_index: None,
+                                },
+                            ));
+                            (None, NcMethodStatus::Ok)
+                        }
+                        _ => (
+                            Some("Property value was invalid".to_string()),
+                            NcMethodStatus::ParameterError,
+                        ),
                     }
-                    (
-                        Some("Property value was invalid".to_string()),
-                        NcMethodStatus::ParameterError,
-                    )
                 }
                 1 | 2 | 3 | 4 | 5 | 7 | 8 => (
                     Some("Property is readonly".to_string()),
@@ -122,20 +142,20 @@ impl NcMember for NcObject {
                 ),
                 _ => (
                     Some("Could not find the property".to_string()),
-                    NcMethodStatus::BadOid,
+                    NcMethodStatus::PropertyNotImplemented,
                 ),
             }
         } else {
             (
                 Some("Could not find the property".to_string()),
-                NcMethodStatus::BadOid,
+                NcMethodStatus::PropertyNotImplemented,
             )
         }
     }
     fn invoke_method(
         &self,
         _oid: u64,
-        _method_id: ElementId,
+        _method_id: NcElementId,
         _args: Value,
     ) -> (Option<String>, Option<Value>, NcMethodStatus) {
         //TODO: This is where we can add treatment for other methods in NcObject
@@ -170,6 +190,327 @@ impl NcObject {
             touchpoints,
             runtime_property_constraints,
             notifier,
+        }
+    }
+
+    pub fn get_class_descriptor(_include_inherited: bool) -> NcClassDescriptor {
+        let properties = vec![
+            NcPropertyDescriptor {
+                base: crate::data_types::NcDescriptor { description: Some("Static value. All instances of the same class will have the same identity value".to_string()) },
+                id: NcElementId { level: 1, index: 1 },
+                name: "classId".to_string(),
+                type_name: Some("NcClassId".to_string()),
+                is_read_only: true,
+                is_nullable: false,
+                is_sequence: false,
+                is_deprecated: false,
+                constraints: None,
+            },
+            NcPropertyDescriptor {
+                base: crate::data_types::NcDescriptor { description: Some("Object identifier".to_string()) },
+                id: NcElementId { level: 1, index: 2 },
+                name: "oid".to_string(),
+                type_name: Some("NcOid".to_string()),
+                is_read_only: true,
+                is_nullable: false,
+                is_sequence: false,
+                is_deprecated: false,
+                constraints: None,
+            },
+            NcPropertyDescriptor {
+                base: crate::data_types::NcDescriptor { description: Some("TRUE iff OID is hardwired into device".to_string()) },
+                id: NcElementId { level: 1, index: 3 },
+                name: "constantOid".to_string(),
+                type_name: Some("NcBoolean".to_string()),
+                is_read_only: true,
+                is_nullable: false,
+                is_sequence: false,
+                is_deprecated: false,
+                constraints: None,
+            },
+            NcPropertyDescriptor {
+                base: crate::data_types::NcDescriptor { description: Some("OID of containing block. Can only ever be null for the root block".to_string()) },
+                id: NcElementId { level: 1, index: 4 },
+                name: "owner".to_string(),
+                type_name: Some("NcOid".to_string()),
+                is_read_only: true,
+                is_nullable: true,
+                is_sequence: false,
+                is_deprecated: false,
+                constraints: None,
+            },
+            NcPropertyDescriptor {
+                base: crate::data_types::NcDescriptor { description: Some("role of obj in containing block".to_string()) },
+                id: NcElementId { level: 1, index: 5 },
+                name: "role".to_string(),
+                type_name: Some("NcString".to_string()),
+                is_read_only: true,
+                is_nullable: false,
+                is_sequence: false,
+                is_deprecated: false,
+                constraints: None,
+            },
+            NcPropertyDescriptor {
+                base: crate::data_types::NcDescriptor { description: Some("Scribble strip".to_string()) },
+                id: NcElementId { level: 1, index: 6 },
+                name: "userLabel".to_string(),
+                type_name: Some("NcString".to_string()),
+                is_read_only: false,
+                is_nullable: true,
+                is_sequence: false,
+                is_deprecated: false,
+                constraints: None,
+            },
+            NcPropertyDescriptor {
+                base: crate::data_types::NcDescriptor { description: Some("Touchpoints to other contexts".to_string()) },
+                id: NcElementId { level: 1, index: 7 },
+                name: "touchpoints".to_string(),
+                type_name: Some("NcTouchpoint".to_string()),
+                is_read_only: true,
+                is_nullable: true,
+                is_sequence: true,
+                is_deprecated: false,
+                constraints: None,
+            },
+            NcPropertyDescriptor {
+                base: crate::data_types::NcDescriptor { description: Some("Runtime property constraints".to_string()) },
+                id: NcElementId { level: 1, index: 8 },
+                name: "runtimePropertyConstraints".to_string(),
+                type_name: Some("NcPropertyConstraints".to_string()),
+                is_read_only: true,
+                is_nullable: true,
+                is_sequence: true,
+                is_deprecated: false,
+                constraints: None,
+            },
+        ];
+
+        let methods = vec![
+            NcMethodDescriptor {
+                base: crate::data_types::NcDescriptor {
+                    description: Some("Get property value".to_string()),
+                },
+                id: NcElementId { level: 1, index: 1 },
+                name: "Get".to_string(),
+                result_datatype: "NcMethodResultPropertyValue".to_string(),
+                parameters: vec![NcParameterDescriptor {
+                    base: crate::data_types::NcDescriptor {
+                        description: Some("Property id".to_string()),
+                    },
+                    name: "id".to_string(),
+                    type_name: Some("NcPropertyId".to_string()),
+                    is_nullable: false,
+                    is_sequence: false,
+                    constraints: None,
+                }],
+                is_deprecated: false,
+            },
+            NcMethodDescriptor {
+                base: crate::data_types::NcDescriptor {
+                    description: Some("Set property value".to_string()),
+                },
+                id: NcElementId { level: 1, index: 2 },
+                name: "Set".to_string(),
+                result_datatype: "NcMethodResult".to_string(),
+                parameters: vec![
+                    NcParameterDescriptor {
+                        base: crate::data_types::NcDescriptor {
+                            description: Some("Property id".to_string()),
+                        },
+                        name: "id".to_string(),
+                        type_name: Some("NcPropertyId".to_string()),
+                        is_nullable: false,
+                        is_sequence: false,
+                        constraints: None,
+                    },
+                    NcParameterDescriptor {
+                        base: crate::data_types::NcDescriptor {
+                            description: Some("Property value".to_string()),
+                        },
+                        name: "value".to_string(),
+                        type_name: None,
+                        is_nullable: true,
+                        is_sequence: false,
+                        constraints: None,
+                    },
+                ],
+                is_deprecated: false,
+            },
+            NcMethodDescriptor {
+                base: crate::data_types::NcDescriptor {
+                    description: Some("Get sequence item".to_string()),
+                },
+                id: NcElementId { level: 1, index: 3 },
+                name: "GetSequenceItem".to_string(),
+                result_datatype: "NcMethodResultPropertyValue".to_string(),
+                parameters: vec![
+                    NcParameterDescriptor {
+                        base: crate::data_types::NcDescriptor {
+                            description: Some("Property id".to_string()),
+                        },
+                        name: "id".to_string(),
+                        type_name: Some("NcPropertyId".to_string()),
+                        is_nullable: false,
+                        is_sequence: false,
+                        constraints: None,
+                    },
+                    NcParameterDescriptor {
+                        base: crate::data_types::NcDescriptor {
+                            description: Some("Index of item in the sequence".to_string()),
+                        },
+                        name: "index".to_string(),
+                        type_name: Some("NcId".to_string()),
+                        is_nullable: false,
+                        is_sequence: false,
+                        constraints: None,
+                    },
+                ],
+                is_deprecated: false,
+            },
+            NcMethodDescriptor {
+                base: crate::data_types::NcDescriptor {
+                    description: Some("Set sequence item value".to_string()),
+                },
+                id: NcElementId { level: 1, index: 4 },
+                name: "SetSequenceItem".to_string(),
+                result_datatype: "NcMethodResult".to_string(),
+                parameters: vec![
+                    NcParameterDescriptor {
+                        base: crate::data_types::NcDescriptor {
+                            description: Some("Property id".to_string()),
+                        },
+                        name: "id".to_string(),
+                        type_name: Some("NcPropertyId".to_string()),
+                        is_nullable: false,
+                        is_sequence: false,
+                        constraints: None,
+                    },
+                    NcParameterDescriptor {
+                        base: crate::data_types::NcDescriptor {
+                            description: Some("Index of item in the sequence".to_string()),
+                        },
+                        name: "index".to_string(),
+                        type_name: Some("NcId".to_string()),
+                        is_nullable: false,
+                        is_sequence: false,
+                        constraints: None,
+                    },
+                    NcParameterDescriptor {
+                        base: crate::data_types::NcDescriptor {
+                            description: Some("Value".to_string()),
+                        },
+                        name: "value".to_string(),
+                        type_name: None,
+                        is_nullable: true,
+                        is_sequence: false,
+                        constraints: None,
+                    },
+                ],
+                is_deprecated: false,
+            },
+            NcMethodDescriptor {
+                base: crate::data_types::NcDescriptor {
+                    description: Some("Add item to sequence".to_string()),
+                },
+                id: NcElementId { level: 1, index: 5 },
+                name: "AddSequenceItem".to_string(),
+                result_datatype: "NcMethodResultId".to_string(),
+                parameters: vec![
+                    NcParameterDescriptor {
+                        base: crate::data_types::NcDescriptor {
+                            description: Some("Property id".to_string()),
+                        },
+                        name: "id".to_string(),
+                        type_name: Some("NcPropertyId".to_string()),
+                        is_nullable: false,
+                        is_sequence: false,
+                        constraints: None,
+                    },
+                    NcParameterDescriptor {
+                        base: crate::data_types::NcDescriptor {
+                            description: Some("Value".to_string()),
+                        },
+                        name: "value".to_string(),
+                        type_name: None,
+                        is_nullable: true,
+                        is_sequence: false,
+                        constraints: None,
+                    },
+                ],
+                is_deprecated: false,
+            },
+            NcMethodDescriptor {
+                base: crate::data_types::NcDescriptor {
+                    description: Some("Delete sequence item".to_string()),
+                },
+                id: NcElementId { level: 1, index: 6 },
+                name: "RemoveSequenceItem".to_string(),
+                result_datatype: "NcMethodResult".to_string(),
+                parameters: vec![
+                    NcParameterDescriptor {
+                        base: crate::data_types::NcDescriptor {
+                            description: Some("Property id".to_string()),
+                        },
+                        name: "id".to_string(),
+                        type_name: Some("NcPropertyId".to_string()),
+                        is_nullable: false,
+                        is_sequence: false,
+                        constraints: None,
+                    },
+                    NcParameterDescriptor {
+                        base: crate::data_types::NcDescriptor {
+                            description: Some("Index of item in the sequence".to_string()),
+                        },
+                        name: "index".to_string(),
+                        type_name: Some("NcId".to_string()),
+                        is_nullable: false,
+                        is_sequence: false,
+                        constraints: None,
+                    },
+                ],
+                is_deprecated: false,
+            },
+            NcMethodDescriptor {
+                base: crate::data_types::NcDescriptor {
+                    description: Some("Get sequence length".to_string()),
+                },
+                id: NcElementId { level: 1, index: 7 },
+                name: "GetSequenceLength".to_string(),
+                result_datatype: "NcMethodResultLength".to_string(),
+                parameters: vec![NcParameterDescriptor {
+                    base: crate::data_types::NcDescriptor {
+                        description: Some("Property id".to_string()),
+                    },
+                    name: "id".to_string(),
+                    type_name: Some("NcPropertyId".to_string()),
+                    is_nullable: false,
+                    is_sequence: false,
+                    constraints: None,
+                }],
+                is_deprecated: false,
+            },
+        ];
+
+        let events = vec![NcEventDescriptor {
+            base: crate::data_types::NcDescriptor {
+                description: Some("Property changed event".to_string()),
+            },
+            id: NcElementId { level: 1, index: 1 },
+            name: "PropertyChanged".to_string(),
+            event_datatype: "NcPropertyChangedEventData".to_string(),
+            is_deprecated: false,
+        }];
+
+        NcClassDescriptor {
+            base: crate::data_types::NcDescriptor {
+                description: Some("NcObject class descriptor".to_string()),
+            },
+            class_id: vec![1],
+            name: "NcObject".to_string(),
+            fixed_role: None,
+            properties,
+            methods,
+            events,
         }
     }
 }


### PR DESCRIPTION
The following changes have been made:
* adding necessary types including datatype and class descriptor types and types allowing constraints
* for struct datatypes we now have a get_type_descriptor used by the Class Manager
* add the intermediate NcManager entitiy and updated NcDeviceManager to be based on it instead of directly from NcObject
* all classes based on NcObject now offer a get_class_descriptor used by the Class Manager
* add a new Class Manager entity used for datatype and class descriptor discovery via properties or methods
* instantiate the new class manager in main inside the root block
* the root block no longer offers itself in the results of find_members_by_class_id
* added better validation for message handles which now send an Error message when invalid
* tweak various edge cases so they respond with more appropriate statuses